### PR TITLE
Very simplistic Linux support

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -3,7 +3,13 @@ if !exists('g:parinfer_mode')
 endif
 
 if !exists('g:parinfer_dylib_path')
-  let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.dylib'
+	if has('macunix')
+		let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.dylib'
+	elseif has('unix')
+		let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.so'
+	else
+		" I hope we don't come here!
+	endif
 endif
 
 function! s:toggleMode()


### PR DESCRIPTION
I noticed that this primarily worked on mac due to the shared library
having a hard-coded '.dylib' extension. I put a very simplistic
conditional here to make it work on GNU/Linux.