### PR TITLE
Add a check for apple compiled vim to load the appropriate library

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -6,7 +6,12 @@ if !exists('g:parinfer_dylib_path')
   if has('macunix')
     let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.dylib'
   elseif has('unix')
-    let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.so'
+    let s:uname = system("uname")
+    if s:uname == "Darwin\n"
+      let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.dylib'
+    else
+      let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/libcparinfer.so'
+    endif
   elseif has('win32')
     let g:parinfer_dylib_path = expand('<sfile>:p:h:h'). '/cparinfer/target/release/cparinfer.dll'
   else


### PR DESCRIPTION
I noticed vim was trying to load the linux .so file. Noticed that `echo has('macunix')` returns 0. Running macos High Sierra

```$ vim --version
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jul 26 2017 19:10:24)
Included patches: 1-503, 505-642
Compiled by root@apple.com```

Which brought me to the solution found here: https://stackoverflow.com/questions/2842078/how-do-i-detect-os-x-in-my-vimrc-file-so-certain-configurations-will-only-appl