### PR TITLE
Fix bad state when manually setting filetype

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -70,6 +70,9 @@ function! s:process_buffer() abort
   if !g:parinfer_enabled || &paste
     return
   endif
+  if !exists('b:parinfer_last_changedtick')
+    call s:enter_buffer()
+  endif
   if b:parinfer_last_changedtick != b:changedtick
     let l:pos = getpos(".")
     let l:orig_lines = getline(1,line('$'))


### PR DESCRIPTION
When opening a blank buffer and manually `:set filetype=lisp`, the following error would happen:

> Error detected while processing function <SNR>68_event[2]..<SNR>68_process_buffer:
> E121: Undefined variable: b:parinfer_last_changedtick

Not sure if this is the best way of going about this…it seems to be a result of the `BufEnter` hook not running when the `filetype` is set this way (as the buffer has already been entered). I’m unaware of how to detect this state and handle it then, so simply guarding against `b:parinfer_last_changedtick` not being present and then calling `s:enter_buffer`.