### PR TITLE
Don't enable in preview window

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -180,6 +180,12 @@ function! s:initialize_buffer() abort
   if getcmdwintype() !=# ''
     return
   endif
+  
+  " Don't enable if preview window
+  if &previewwindow
+    return
+  endif
+
   for event_name in filter(keys(s:EVENTS),'exists("##".v:val)')
     execute "autocmd! Parinfer ".event_name." <buffer> call <SID>event('".event_name."')"
   endfor


### PR DESCRIPTION
I notice that parinfer doesn't play well with the `:Last` command from fireplace when printing string.
For example, try to evaluate:
```clojure
(str "FOO (x\n y)")
```
And call `:Last` after it. I get some error on vim.

I think a possible solution would be to disable parinfer on the preview window