### PR TITLE
Add logic to handle loading with packadd

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@ ChangeLog
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.0...HEAD[Unreleased]
 ---------------------------------------------------------------------------
 
+* Add support for loading with Vim/Neovim `packadd`
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.3.1...v0.4.0[0.4.0]
 ------------------------------------------------------------------------

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -1,5 +1,3 @@
-let g:parinfer_loaded = v:false
-
 if !exists('g:parinfer_mode')
   let g:parinfer_mode = "smart"
 endif
@@ -217,7 +215,7 @@ augroup Parinfer
 augroup END
 
 " Handle the case where parinfer was lazy-loaded
-if !g:parinfer_loaded && (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy')
+if (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy')
   call <SID>initialize_buffer()
 endif
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -1,3 +1,5 @@
+let g:parinfer_loaded = v:false
+
 if !exists('g:parinfer_mode')
   let g:parinfer_mode = "smart"
 endif
@@ -209,8 +211,16 @@ function! s:initialize_buffer() abort
   endfor
 endfunction
 
+
 augroup Parinfer
   autocmd FileType clojure,scheme,lisp,racket,hy call <SID>initialize_buffer()
 augroup END
+
+" Handle the case where parinfer was lazy-loaded
+if !g:parinfer_loaded && (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy')
+  call <SID>initialize_buffer()
+endif
+
+let g:parinfer_loaded = v:true
 
 " vim:set sts=2 sw=2 ai et foldmethod=marker:


### PR DESCRIPTION
When loading parinfer-rust in Neovim using the "optional plugins" feature (see `:h pack-add`), parinfer would never be initialized until either a new Lisp-family buffer was opened or `set filetype=<some Lisp family language>` was run, because the initialization autocommand only runs on the `FileType` event. This PR fixes this behavior to allow lazy-loading of parinfer-rust by adding a one-time test if the *current* file is one of the filetypes parinfer knows how to handle.

There may well be a cleaner way to write this; I'm not a vimscript expert. This seems to work (tested using `minpac`) without breaking eager-loading, though.