### PR TITLE
[Kakoune] parinfer-enable-window and parinfer-disable-window

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ Add this to your `+kakrc+`
 plug "eraserhd/parinfer-rust" do %{
     cargo install --force --path .
 } config %{
-    hook -group parinfer global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
+    hook global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
         parinfer-enable-window -smart
     }
 }
@@ -92,7 +92,7 @@ Add this to your `+kakrc+`
 
 [source,kak]
 ----
-hook -group parinfer global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
+hook global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
     parinfer-enable-window -smart
 }
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -64,13 +64,18 @@ Add this to your `+kakrc+`
 [source,kak]
 ----
 plug "eraserhd/parinfer-rust" do %{
-    cargo build --release
     cargo install --force --path .
+} config %{
+    hook -group parinfer global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
+        parinfer-enable-window -smart
+    }
 }
 ----
 
 Re-source your `+kakrc+` or restart Kakoune. Then run `+:plug-install+`.
-`+plug.kak+` will download, build and install plugin for you.
+`+plug.kak+` will download, build and install plugin for you. Optionally
+add `+cargo clean+` line to the `+do+` block to clean plugin from build
+files, thus making it load a bit faster.
 
 ==== Manual
 
@@ -82,6 +87,15 @@ $ make install
 $ cargo build --release
 $ cargo install
 ....
+
+Add this to your `+kakrc+`
+
+[source,kak]
+----
+hook -group parinfer global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
+    parinfer-enable-window -smart
+}
+----
 
 === Emacs
 

--- a/rc/parinfer.kak
+++ b/rc/parinfer.kak
@@ -12,8 +12,8 @@ parinfer-enable-window -params ..1 %{
         set-option window parinfer_enabled true
     } catch %{
         # set up recovery hooks that will re-enable parinfer when parens are balanced
-        hook -group parinfer-try-enable window NormalIdle .* parinfer-try-enable
-        hook -group parinfer-try-enable window InsertIdle .* parinfer-try-enable
+        hook -group parinfer-try-paren window NormalIdle .* parinfer-try-paren
+        hook -group parinfer-try-paren window InsertIdle .* parinfer-try-paren
         echo -markup "{Error}parinfer error: %val{error}"
         echo -debug "parinfer error: %val{error}"
     }
@@ -26,7 +26,7 @@ parinfer-enable-window -params ..1 %{
 define-command -docstring "parinfer-disable-window: disable Parinfer for current window." \
 parinfer-disable-window %{
     remove-hooks window parinfer
-    remove-hooks window parinfer-try-enable
+    remove-hooks window parinfer-try-paren
     set-option window parinfer_enabled false
 }
 
@@ -108,11 +108,11 @@ parinfer -params ..2 %{
     }
 }
 
-define-command -hidden -docstring "parinfer-try-enable: try to enable paren mode" \
-parinfer-try-enable %{ try %{
+define-command -hidden -docstring "parinfer-try-paren: try to enable paren mode" \
+parinfer-try-paren %{ try %{
     parinfer -paren
     set-option window parinfer_enabled true
-    remove-hooks window parinfer-try-enable
+    remove-hooks window parinfer-try-paren
 }}
 
 }

--- a/rc/parinfer.kak
+++ b/rc/parinfer.kak
@@ -12,17 +12,17 @@ parinfer-enable-window -params ..1 %{
         set-option window parinfer_enabled true
     } catch %{
         # set up recovery hooks that will re-enable parinfer when parens are balanced
-        hook -group parinfer-try-paren window NormalIdle .* parinfer-try-paren
+        hook -group parinfer-try-paren window NormalKey .* parinfer-try-paren
         hook -group parinfer-try-paren window InsertIdle .* parinfer-try-paren
-        echo -markup "{Error}parinfer error: %val{error}"
-        echo -debug "parinfer error: %val{error}"
+        echo -debug %val{error}
     }
     evaluate-commands %sh{
         mode="${1:-indent}"
         printf "%s\n" "remove-hooks window parinfer
-                       hook -group parinfer window NormalKey .* %{ parinfer -if-enabled $mode }
-                       hook -group parinfer window InsertChar (?!\n).* %{ parinfer -if-enabled $mode }
-                       hook -group parinfer window InsertDelete .* %{ parinfer -if-enabled $mode }"
+                       set-option window parinfer_current_mode '${mode#-}'
+                       hook -group parinfer window NormalKey .* %{ try %{ parinfer -if-enabled $mode } catch %{ echo -markup \"{Error}%val{error}\" } }
+                       hook -group parinfer window InsertChar (?!\n).* %{ try %{ parinfer -if-enabled $mode } catch %{ echo -markup \"{Error}%val{error}\" } }
+                       hook -group parinfer window InsertDelete .* %{ try %{ parinfer -if-enabled $mode } catch %{ echo -markup \"{Error}%val{error}\" } } "
     }
 }
 
@@ -48,13 +48,13 @@ declare-option -hidden str parinfer_previous_timestamp
 declare-option -hidden int parinfer_cursor_char_column
 declare-option -hidden int parinfer_cursor_line
 
-define-command -hidden -docstring "parinfer [<switches>]: reformat buffer with parinfer-rust.
+define-command -docstring "parinfer [<switches>]: reformat buffer with parinfer-rust.
 Switches:
     -if-enabled  Check 'parinfer_enabled' option before applying changes.
     -indent      Preserve indentation and fix parentheses (default).
     -paren       Preserve parentheses and fix indentation.
     -smart       Try to be smart about what to fix." \
-parinfer -params ..2 %{ try %{
+parinfer -params ..2 %{
     evaluate-commands -draft -save-regs '/"|^@' -no-hooks %{
         set buffer parinfer_cursor_char_column %val{cursor_char_column}
         set buffer parinfer_cursor_line %val{cursor_line}
@@ -71,7 +71,6 @@ parinfer -params ..2 %{ try %{
                 esac
                 shift
             done
-            printf "set-option window parinfer_current_mode '%s'\n" "$mode"
             export mode
             if [ -z "${kak_opt_parinfer_previous_timestamp}" ]; then
                 export kak_opt_parinfer_previous_text="${kak_selection}"
@@ -107,10 +106,7 @@ parinfer -params ..2 %{ try %{
         shift
         echo "select ${line}.${column},${line}.${column} $@"
     }
-} catch %{
-    echo -markup "{Error}%val{error}"
-    echo -debug "parinfer-rust error: %val{error}"
-}}
+}
 
 define-command -hidden -docstring "parinfer-try-paren: try to enable paren mode" \
 parinfer-try-paren %{ try %{

--- a/rc/parinfer.kak
+++ b/rc/parinfer.kak
@@ -1,8 +1,8 @@
 define-command -docstring "parinfer-enable-window [<mode>]: enable Parinfer for current window.
 Modes:
-    -indent  Preserve indentation and fix parentheses (default).
+    -indent  Preserve indentation and fix parentheses.
     -paren   Preserve parentheses and fix indentation.
-    -smart   Try to be smart about what to fix." \
+    -smart   Try to be smart about what to fix (default)." \
 parinfer-enable-window -params ..1 %{
     require-module parinfer
     try %{
@@ -17,7 +17,7 @@ parinfer-enable-window -params ..1 %{
         echo -debug %val{error}
     }
     evaluate-commands %sh{
-        mode="${1:-indent}"
+        mode="${1:-smart}"
         printf "%s\n" "remove-hooks window parinfer
                        set-option window parinfer_current_mode '${mode#-}'
                        hook -group parinfer window NormalKey .* %{ try %{ parinfer -if-enabled $mode } catch %{ echo -markup \"{Error}%val{error}\" } }


### PR DESCRIPTION
Fix #53 
Probably fix, or make it more straightforward #43

I have a question about `-if-enabled` switch. In [Emacs package that I use](https://github.com/DogLooksGood/parinfer-mode) there's a mechanism that checks if buffer parens are balanced. If not, it starts in `paren-mode` and allows user to decide what to do. I've thought that `-if-enabled paren` should do the same. However if parens unbalanced, paren mode refuse to start. So I've changed default behavior a bit. In short:

- we try to enable paren mode with `parinfer -paren`
  - if we succeed, we set `parinfer_enable` to true
  - if not, we set special hooks that will try to enable paren mode when possible (maybe this should be optional?)
- we set hooks for parinfer with `-if-enable` switch, effectively deferring those until parens are balanced.

What do you think?