### PR TITLE
Don't take a reference to a function pointer

### DIFF
--- a/src/c_wrapper.rs
+++ b/src/c_wrapper.rs
@@ -55,7 +55,7 @@ mod reference_hack {
             dli_sname: ptr::null(),
             dli_saddr: ptr::null_mut()
         };
-        let initialize_ptr: *const c_void = &initialize as *const _ as *const c_void;
+        let initialize_ptr: *const c_void = initialize as *const c_void;
         if dladdr(initialize_ptr, &mut info) == 0 {
             panic!("Could not get parinfer library path.");
         }


### PR DESCRIPTION
Before the code failed on the 1.39 beta and newer.

I've narrowed down on the issue here https://stackoverflow.com/questions/58416511/casting-a-function-reference-producing-an-invalid-pointer