### PR TITLE
docs: mention nixos command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,6 +64,13 @@ Plug 'eraserhd/parinfer-rust', {'do':
         \  'cargo build --release'}
 ----
 
+If you are a NixOS user, you can use this command instead:
+[source,viml]
+----
+Plug 'eraserhd/parinfer-rust', {'do':
+        \ 'nix-shell --run \"cargo build --release \"'}
+----
+
 === Kakoune
 
 ==== `+plug.kak+`


### PR DESCRIPTION
After my last `PlugUpdate`, I was having some problems building the project because of the new clang dependency. But then I notice the nix files in the repo :-)
It can help others to mention how to compile the project for nix users.

Related to this, since I see that you also maintain a parinfer-rust package in nixpkgs, would make sense to you if the vim plugin looks for the system parinfer-rust and uses it? In that case, if your distro has the package, you can avoid compiling it locally.