### PR TITLE
Add support for user-defined comment characters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,13 @@ ChangeLog
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
 ---------------------------------------------------------------------------
 
+=== Added
+
+* The user can now set the character used to denote comments. The
+  character can be set on a global or per-buffer basis (using
+  `g:parinfer_comment_char` and `b:parinfer_comment_char` respectively).
+  By default, the global character is `;` and the character for Janet
+  buffers is `#`.
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -200,6 +200,7 @@ This wouldn’t be possible without the work of others:
 * Case Nelson - Writing the nvim-parinfer, from which VimL code and some
   inspiration was stolen.
 * Justin Barclay - Emacs module.
+* Michael Camilleri - User-defined comments.
 
 == License
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -7,6 +7,9 @@ endif
 if !exists('g:parinfer_force_balance')
   let g:parinfer_force_balance = 0
 endif
+if !exists('g:parinfer_comment_char')
+  let g:parinfer_comment_char = ";"
+endif
 
 if !exists('g:parinfer_dylib_path')
   let s:libdir = expand('<sfile>:p:h:h') . '/target/release'
@@ -28,6 +31,9 @@ endif
 
 command! ParinferOn let g:parinfer_enabled = 1
 command! ParinferOff let g:parinfer_enabled = 0
+
+" Comment settings
+au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
 
 " Logging {{{1
 
@@ -134,13 +140,17 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_last_changedtick')
     call s:enter_buffer()
   endif
+  if !exists('b:parinfer_comment_char')
+    let b:parinfer_comment_char = g:parinfer_comment_char
+  end
   if b:parinfer_last_changedtick != b:changedtick
     let l:cursor = s:get_cursor_position()
     let l:orig_lines = getline(1,'$')
     let l:orig_text = join(l:orig_lines, "\n")
     let l:request = { "mode": g:parinfer_mode,
                     \ "text": l:orig_text,
-                    \ "options": { "cursorX": l:cursor[2],
+                    \ "options": { "commentChar": b:parinfer_comment_char,
+                                 \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -142,7 +142,7 @@ function! s:process_buffer() abort
   endif
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
-  end
+  endif
   if b:parinfer_last_changedtick != b:changedtick
     let l:cursor = s:get_cursor_position()
     let l:orig_lines = getline(1,'$')

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -28,6 +28,7 @@ fn options() -> getopts::Options {
     options.optopt("", "input-format", "'json', 'text' (default: 'text')", "FMT");
     options.optopt("m", "mode", "parinfer mode (indent, paren, or smart) (default: smart)", "MODE");
     options.optopt("", "output-format", "'json', 'kakoune', 'text' (default: 'text')", "FMT");
+    options.optopt("", "comment-char", "(default: ';')", "CC");
     options
 }
 
@@ -77,6 +78,14 @@ impl Options {
         }
     }
 
+    fn comment_char(&self) -> char {
+        match self.matches.opt_str("comment-char") {
+            None => ';',
+            Some(ref s) if s.chars().count() == 1 =>  s.chars().next().unwrap(),
+            Some(ref _s) => panic!("comment character must be a single character")
+        }
+    }
+
     pub fn request(&self) -> io::Result<Request> {
         match self.input_type() {
             InputType::Text => {
@@ -94,6 +103,7 @@ impl Options {
                         prev_cursor_line: None,
                         force_balance: false,
                         return_parens: false,
+                        comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None
                     }
@@ -121,6 +131,7 @@ impl Options {
                             .ok(),
                         force_balance: false,
                         return_parens: false,
+                        comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None
                     }

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -122,6 +122,7 @@ fn make_option() -> Result<Options> {
     partial_result: false,
     force_balance: false,
     return_parens: false,
+    comment_char: ';',
   })
 }
 
@@ -151,6 +152,7 @@ fn new_options(
     partial_result: false,
     force_balance: false,
     return_parens: false,
+    comment_char: ';',
   })
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,8 @@ pub struct Options {
     pub force_balance: bool,
     #[serde(default = "Options::default_false")]
     pub return_parens: bool,
+    #[serde(default = "Options::default_comment")]
+    pub comment_char: char,
 }
 
 impl Options {
@@ -44,6 +46,10 @@ impl Options {
 
     fn default_false() -> bool {
         false
+    }
+
+    fn default_comment() -> char {
+        ';'
     }
 }
 


### PR DESCRIPTION
The parinfer-rust library is written with the assumption that `;` denotes comments. While this is true in most Lisps, it is not true in [Janet](https://janet-lang.org/docs/syntax.html). Worse, the `;` character can have an important semantic meaning (again, this is the case in Janet).

At present, this makes the use of parinfer-rust in Janet dangerous at best. The code in this PR solves the issue by allowing the user to specify the character to use for denoting comments at the time of each call (by default, the value is `;`). In the revised `plugin/parinfer.vim` file, the plugin will use the value of `b:parinfer_comment_char` for the comment character (this is set to `;` if not defined for the buffer).

This is my first time writing any code in Rust and there is very likely mistakes in how I've gone about implementing this. Please feel free to correct as necessary.

This fixes #37.