### PR TITLE
Add Janet long string support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
   `g:parinfer_comment_char` and `b:parinfer_comment_char` respectively).
   By default, the global character is `;` and the character for Janet
   buffers is `#`.
+* Add support for Janet's long strings.
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -9,6 +9,7 @@ if !exists('g:parinfer_force_balance')
 endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
+endif
 if !exists('g:parinfer_janet_long_strings')
   let g:parinfer_janet_long_strings = 0
 endif
@@ -147,6 +148,7 @@ function! s:process_buffer() abort
   endif
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
+  endif
   if !exists('b:parinfer_janet_long_strings')
     let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -9,8 +9,8 @@ if !exists('g:parinfer_force_balance')
 endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
-if !exists('g:parinfer_long_strings')
-  let g:parinfer_long_strings = 0
+if !exists('g:parinfer_janet_long_strings')
+  let g:parinfer_janet_long_strings = 0
 endif
 
 if !exists('g:parinfer_dylib_path')
@@ -38,7 +38,7 @@ command! ParinferOff let g:parinfer_enabled = 0
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
 
 " Long strings settings
-au BufNewFile,BufRead *.janet let b:parinfer_long_strings = 1
+au BufNewFile,BufRead *.janet let b:parinfer_janet_long_strings = 1
 
 " Logging {{{1
 
@@ -147,8 +147,8 @@ function! s:process_buffer() abort
   endif
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
-  if !exists('b:parinfer_long_strings')
-    let b:parinfer_long_strings = g:parinfer_long_strings
+  if !exists('b:parinfer_janet_long_strings')
+    let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif
   if b:parinfer_last_changedtick != b:changedtick
     let l:cursor = s:get_cursor_position()
@@ -160,7 +160,7 @@ function! s:process_buffer() abort
                                  \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
-                                 \ "longStrings": b:parinfer_long_strings ? v:true : v:false,
+                                 \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],
                                  \ "prevText": b:parinfer_previous_text } }

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -9,6 +9,8 @@ if !exists('g:parinfer_force_balance')
 endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
+if !exists('g:parinfer_long_strings')
+  let g:parinfer_long_strings = 0;
 endif
 
 if !exists('g:parinfer_dylib_path')
@@ -34,6 +36,9 @@ command! ParinferOff let g:parinfer_enabled = 0
 
 " Comment settings
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
+
+" Long strings settings
+au BufNewFile,BufRead *.janet let b:parinfer_long_strings = 1
 
 " Logging {{{1
 
@@ -142,6 +147,8 @@ function! s:process_buffer() abort
   endif
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
+  if !exists('b:parinfer_long_strings')
+    let b:parinfer_long_strings = g:parinfer_long_strings
   endif
   if b:parinfer_last_changedtick != b:changedtick
     let l:cursor = s:get_cursor_position()
@@ -153,6 +160,7 @@ function! s:process_buffer() abort
                                  \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
+                                 \ "longStrings": b:parinfer_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],
                                  \ "prevText": b:parinfer_previous_text } }

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -10,7 +10,7 @@ endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
 if !exists('g:parinfer_long_strings')
-  let g:parinfer_long_strings = 0;
+  let g:parinfer_long_strings = 0
 endif
 
 if !exists('g:parinfer_dylib_path')

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -106,7 +106,7 @@ impl Options {
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None,
-                        long_strings: false
+                        janet_long_strings: false
                     }
                 })
             },
@@ -135,7 +135,7 @@ impl Options {
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None,
-                        long_strings: false
+                        janet_long_strings: false
                     }
                 })
             },

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -105,7 +105,8 @@ impl Options {
                         return_parens: false,
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
-                        selection_start_line: None
+                        selection_start_line: None,
+                        long_strings: false
                     }
                 })
             },
@@ -133,7 +134,8 @@ impl Options {
                         return_parens: false,
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
-                        selection_start_line: None
+                        selection_start_line: None,
+                        long_strings: false
                     }
                 })
             },

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -123,7 +123,7 @@ fn make_option() -> Result<Options> {
     force_balance: false,
     return_parens: false,
     comment_char: ';',
-    long_strings: false,
+    janet_long_strings: false,
   })
 }
 
@@ -154,7 +154,7 @@ fn new_options(
     force_balance: false,
     return_parens: false,
     comment_char: ';',
-    long_strings: false,
+    janet_long_strings: false,
   })
 }
 

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -123,6 +123,7 @@ fn make_option() -> Result<Options> {
     force_balance: false,
     return_parens: false,
     comment_char: ';',
+    long_strings: false,
   })
 }
 
@@ -153,6 +154,7 @@ fn new_options(
     force_balance: false,
     return_parens: false,
     comment_char: ';',
+    long_strings: false,
   })
 }
 

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -181,6 +181,7 @@ struct State<'a> {
     is_in_comment: bool,
     comment_x: Option<Column>,
 
+    long_strings_enabled: bool,
     str_started: bool,
     quote_open_delim: String,
     quote_close_delim: String,
@@ -266,6 +267,7 @@ fn get_initial_result<'a>(
         is_in_comment: false,
         comment_x: None,
 
+        long_strings_enabled: options.long_strings,
         str_started: false,
         quote_open_delim: String::with_capacity(5),
         quote_close_delim: String::with_capacity(5),
@@ -827,6 +829,10 @@ fn on_quote<'a>(result: &mut State<'a>) {
 }
 
 fn on_lquote<'a>(result: &mut State<'a>) {
+    if !result.long_strings_enabled {
+        return;
+    }
+
     if result.is_in_str && is_valid_quote(&result.quote_open_delim, result.ch) {
         if result.str_started {
             result.quote_close_delim.push_str(result.ch);

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -181,7 +181,7 @@ struct State<'a> {
     is_in_comment: bool,
     comment_x: Option<Column>,
 
-    long_strings_enabled: bool,
+    janet_long_strings_enabled: bool,
     str_started: bool,
     quote_open_delim: String,
     quote_close_delim: String,
@@ -267,7 +267,7 @@ fn get_initial_result<'a>(
         is_in_comment: false,
         comment_x: None,
 
-        long_strings_enabled: options.long_strings,
+        janet_long_strings_enabled: options.janet_long_strings,
         str_started: false,
         quote_open_delim: String::with_capacity(5),
         quote_close_delim: String::with_capacity(5),
@@ -838,7 +838,7 @@ fn on_quote<'a>(result: &mut State<'a>) {
 }
 
 fn on_lquote<'a>(result: &mut State<'a>) {
-    if !result.long_strings_enabled {
+    if !result.janet_long_strings_enabled {
         return;
     }
 

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -636,6 +636,15 @@ fn is_valid_quote<'a>(delim: &'a str, ch: &'a str) -> bool {
     }
 }
 
+#[cfg(test)]
+#[test]
+fn is_valid_quote_works() {
+    assert!(is_valid_quote("", "`"));
+    assert!(is_valid_quote("`", "`"));
+    assert!(!is_valid_quote("\"", "`"));
+}
+
+
 // {{{1 Advanced operations on characters
 
 fn check_cursor_holding<'a>(result: &State<'a>) -> Result<bool> {

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -903,6 +903,7 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
 
     if result.is_in_str && ch != TILDE {
         result.str_started = true;
+        result.quote_close_delim.clear();
     }
 
     ch = result.ch;

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ pub struct Options {
     #[serde(default = "Options::default_comment")]
     pub comment_char: char,
     #[serde(default = "Options::default_false")]
-    pub long_strings: bool,
+    pub janet_long_strings: bool,
 }
 
 impl Options {

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,8 @@ pub struct Options {
     pub return_parens: bool,
     #[serde(default = "Options::default_comment")]
     pub comment_char: char,
+    #[serde(default = "Options::default_false")]
+    pub long_strings: bool,
 }
 
 impl Options {

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -143,7 +143,10 @@ struct Options {
     prev_cursor_x: Option<Column>,
     #[serde(skip_serializing_if = "Option::is_none")]
     prev_cursor_line: Option<LineNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    long_strings: Option<bool>,
 }
+
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -273,6 +276,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             cursor_x: None,
             cursor_line: None,
             changes: None,
+            long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -313,6 +317,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
                     new_text: String::from("xyååå"),
                 }
             ]),
+            long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -353,12 +358,47 @@ pub fn wide_characters() {
                     new_text: String::from("ｗｏｒｌｄ"),
                 }
             ]),
+            long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
     };
     let input = json!({
         "mode": "smart",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
+pub fn long_strings() {
+    let case = Case {
+        text: String::from("(def foo {:bar `Not a closing parenthesis )`})"),
+        result: CaseResult {
+            text: String::from("(def foo {:bar `Not a closing parenthesis )`})"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            long_strings: Some(true),
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "paren",
         "text": &case.text,
         "options": &case.options
     }).to_string();

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -144,7 +144,7 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     prev_cursor_line: Option<LineNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    long_strings: Option<bool>,
+    janet_long_strings: Option<bool>,
 }
 
 
@@ -276,7 +276,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             cursor_x: None,
             cursor_line: None,
             changes: None,
-            long_strings: None,
+            janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -317,7 +317,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
                     new_text: String::from("xyååå"),
                 }
             ]),
-            long_strings: None,
+            janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -358,7 +358,7 @@ pub fn wide_characters() {
                     new_text: String::from("ｗｏｒｌｄ"),
                 }
             ]),
-            long_strings: None,
+            janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -373,7 +373,7 @@ pub fn wide_characters() {
 }
 
 #[test]
-pub fn long_strings() {
+pub fn janet_long_strings() {
     let case = Case {
         text: String::from("(def foo {:bar `Not a closing parenthesis )`})"),
         result: CaseResult {
@@ -392,7 +392,7 @@ pub fn long_strings() {
             cursor_x: None,
             cursor_line: None,
             changes: None,
-            long_strings: Some(true),
+            janet_long_strings: Some(true),
             prev_cursor_x: None,
             prev_cursor_line: None
         }


### PR DESCRIPTION
While I think #70 has general application, I'm less certain about this PR. Curious for any feedback.

Janet supports Python-like [long strings](https://janet-lang.org/docs/strings.html). These are strings delimited by one or more `` ` ``. Unlike strings delimited by `"`, they preserve whitespace and do not support escape characters. Without this support, there can be situations where parinfer-rust will add parentheses 'inside' a long string because it does not recognise the characters inside `` ` `` as being inside a string.

A complicating element of the implementation is that long strings can be delimited by one or more `` ` ``. The solution used here is to track the number of backticks that 'opened' the string and the number of backticks that appear to be 'closing' the string.