### PR TITLE
Add option to ignore parens in enclosed symbols

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -10,6 +10,9 @@ endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
 endif
+if !exists('g:parinfer_lisp_vline_symbols')
+  let g:parinfer_lisp_vline_symbols = 0
+endif
 if !exists('g:parinfer_janet_long_strings')
   let g:parinfer_janet_long_strings = 0
 endif
@@ -34,6 +37,10 @@ endif
 
 command! ParinferOn let g:parinfer_enabled = 1
 command! ParinferOff let g:parinfer_enabled = 0
+
+" Common Lisp and Scheme: ignore parens in symbols enclosed by ||
+au BufNewFile,BufRead *.lsp,*.lisp,*.cl,*.L,sbclrc,.sbclrc let b:parinfer_lisp_vline_symbols = 1
+au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_lisp_vline_symbols = 1
 
 " Comment settings
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
@@ -149,6 +156,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
   endif
+  if !exists('b:parinfer_lisp_vline_symbols')
+    let b:parinfer_lisp_vline_symbols = g:parinfer_lisp_vline_symbols
+  endif
   if !exists('b:parinfer_janet_long_strings')
     let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif
@@ -162,6 +172,7 @@ function! s:process_buffer() abort
                                  \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
+                                 \ "lispVLineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -106,6 +106,7 @@ impl Options {
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None,
+                        lisp_vline_symbols: false,
                         janet_long_strings: false
                     }
                 })
@@ -135,6 +136,7 @@ impl Options {
                         comment_char: char::from(self.comment_char()),
                         partial_result: false,
                         selection_start_line: None,
+                        lisp_vline_symbols: false,
                         janet_long_strings: false
                     }
                 })

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -123,6 +123,7 @@ fn make_option() -> Result<Options> {
     force_balance: false,
     return_parens: false,
     comment_char: ';',
+    lisp_vline_symbols: false,
     janet_long_strings: false,
   })
 }
@@ -154,6 +155,7 @@ fn new_options(
     force_balance: false,
     return_parens: false,
     comment_char: ';',
+    lisp_vline_symbols: false,
     janet_long_strings: false,
   })
 }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -12,6 +12,7 @@ const BACKSLASH: &'static str = "\\";
 const BLANK_SPACE: &'static str = " ";
 const DOUBLE_SPACE: &'static str = "  ";
 const DOUBLE_QUOTE: &'static str = "\"";
+const VERTICAL_LINE: &'static str = "|";
 const NEWLINE: &'static str = "\n";
 const TAB: &'static str = "\t";
 const TILDE: &'static str = "`";
@@ -897,6 +898,8 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
     } else if is_close_paren(ch) {
         on_close_paren(result)?;
     } else if ch == DOUBLE_QUOTE {
+        on_quote(result);
+    } else if ch == VERTICAL_LINE {
         on_quote(result);
     } else if ch == TILDE {
         on_lquote(result);

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,8 @@ pub struct Options {
     #[serde(default = "Options::default_comment")]
     pub comment_char: char,
     #[serde(default = "Options::default_false")]
+    pub lisp_vline_symbols: bool,
+    #[serde(default = "Options::default_false")]
     pub janet_long_strings: bool,
 }
 

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -144,6 +144,8 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     prev_cursor_line: Option<LineNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    lisp_vline_symbols: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
 }
 
@@ -276,6 +278,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             cursor_x: None,
             cursor_line: None,
             changes: None,
+            lisp_vline_symbols: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -317,6 +320,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
                     new_text: String::from("xyååå"),
                 }
             ]),
+            lisp_vline_symbols: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -358,6 +362,7 @@ pub fn wide_characters() {
                     new_text: String::from("ｗｏｒｌｄ"),
                 }
             ]),
+            lisp_vline_symbols: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -365,6 +370,41 @@ pub fn wide_characters() {
     };
     let input = json!({
         "mode": "smart",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
+pub fn lisp_vline_symbols() {
+    let case = Case {
+        text: String::from("(define foo |Not a closing parenthesis )|)"),
+        result: CaseResult {
+            text: String::from("(define foo |Not a closing parenthesis )|)"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            lisp_vline_symbols: Some(true),
+            janet_long_strings: None,
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "paren",
         "text": &case.text,
         "options": &case.options
     }).to_string();
@@ -392,6 +432,7 @@ pub fn janet_long_strings() {
             cursor_x: None,
             cursor_line: None,
             changes: None,
+            lisp_vline_symbols: None,
             janet_long_strings: Some(true),
             prev_cursor_x: None,
             prev_cursor_line: None


### PR DESCRIPTION
Closes #77

I am a (neo)vim user so I confirmed that this change works fine for (neo)vim. For emacs and kakoune I am not sure.