### PR TITLE
Turn on lisp_vline_symbols option only in lisp/scheme

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -172,7 +172,7 @@ function! s:process_buffer() abort
                                  \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
-                                 \ "lispVLineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
+                                 \ "lispVlineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -182,6 +182,8 @@ struct State<'a> {
     is_in_comment: bool,
     comment_x: Option<Column>,
 
+    lisp_vline_symbols_enabled: bool,
+
     janet_long_strings_enabled: bool,
     str_started: bool,
     quote_open_delim: String,
@@ -267,6 +269,8 @@ fn get_initial_result<'a>(
         is_in_str: false,
         is_in_comment: false,
         comment_x: None,
+
+        lisp_vline_symbols_enabled: options.lisp_vline_symbols,
 
         janet_long_strings_enabled: options.janet_long_strings,
         str_started: false,
@@ -900,7 +904,9 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
     } else if ch == DOUBLE_QUOTE {
         on_quote(result);
     } else if ch == VERTICAL_LINE {
-        on_quote(result);
+        if result.lisp_vline_symbols_enabled {
+            on_quote(result);
+        }
     } else if ch == TILDE {
         on_lquote(result);
     } else if ch == result.comment_char {


### PR DESCRIPTION
My bad, I forgot to turn off parsing `|` if `lisp_vline_symbols` is disabled. Fix #77 