### PR TITLE
Add option to ignore parens in lisp/scheme block comments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,9 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
   buffers is `#`.
 * Add support for Janet's long strings.
 * Support for WebAssembly
+* More support for Common Lisp and Scheme:
+  - `|Enclosed symbols|`
+  - `#|Block comments|#`
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -201,6 +201,7 @@ This wouldn’t be possible without the work of others:
   inspiration was stolen.
 * Justin Barclay - Emacs module.
 * Michael Camilleri - User-defined comments.
+* Mitsuhiro Nakamura - Support for Common Lisp and Scheme.
 
 == License
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -13,6 +13,9 @@ endif
 if !exists('g:parinfer_lisp_vline_symbols')
   let g:parinfer_lisp_vline_symbols = 0
 endif
+if !exists('g:parinfer_lisp_block_comment')
+  let g:parinfer_lisp_block_comment = 0
+endif
 if !exists('g:parinfer_janet_long_strings')
   let g:parinfer_janet_long_strings = 0
 endif
@@ -41,6 +44,10 @@ command! ParinferOff let g:parinfer_enabled = 0
 " Common Lisp and Scheme: ignore parens in symbols enclosed by ||
 au BufNewFile,BufRead *.lsp,*.lisp,*.cl,*.L,sbclrc,.sbclrc let b:parinfer_lisp_vline_symbols = 1
 au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_lisp_vline_symbols = 1
+
+" Common Lisp and Scheme: ignore parens in block comments
+au BufNewFile,BufRead *.lsp,*.lisp,*.cl,*.L,sbclrc,.sbclrc let b:parinfer_lisp_block_comment = 1
+au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_lisp_block_comment = 1
 
 " Comment settings
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
@@ -159,6 +166,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_lisp_vline_symbols')
     let b:parinfer_lisp_vline_symbols = g:parinfer_lisp_vline_symbols
   endif
+  if !exists('b:parinfer_lisp_block_comment')
+    let b:parinfer_lisp_block_comment = g:parinfer_lisp_block_comment
+  endif
   if !exists('b:parinfer_janet_long_strings')
     let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif
@@ -173,6 +183,7 @@ function! s:process_buffer() abort
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
                                  \ "lispVlineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
+                                 \ "lispBlockComment": b:parinfer_lisp_block_comment ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -107,6 +107,7 @@ impl Options {
                         partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols: false,
+                        lisp_block_comment: false,
                         janet_long_strings: false
                     }
                 })
@@ -137,6 +138,7 @@ impl Options {
                         partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols: false,
+                        lisp_block_comment: false,
                         janet_long_strings: false
                     }
                 })

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -124,6 +124,7 @@ fn make_option() -> Result<Options> {
     return_parens: false,
     comment_char: ';',
     lisp_vline_symbols: false,
+    lisp_block_comment: false,
     janet_long_strings: false,
   })
 }
@@ -156,6 +157,7 @@ fn new_options(
     return_parens: false,
     comment_char: ';',
     lisp_vline_symbols: false,
+    lisp_block_comment: false,
     janet_long_strings: false,
   })
 }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -170,7 +170,11 @@ enum In<'a> {
 
 impl<'a> State<'a> {
     fn is_in_code(&'a self) -> bool {
-        match self.context { In::Code => true, _ => false }
+        match self.context {
+            In::Code => true,
+            In::LispReaderSyntax => true,
+            _ => false
+        }
     }
     fn is_in_comment(&'a self) -> bool {
         match self.context { In::Comment => true, _ => false }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -15,7 +15,7 @@ const DOUBLE_QUOTE: &'static str = "\"";
 const VERTICAL_LINE: &'static str = "|";
 const NEWLINE: &'static str = "\n";
 const TAB: &'static str = "\t";
-const TILDE: &'static str = "`";
+const GRAVE: &'static str = "`";
 
 fn match_paren(paren: &str) -> Option<&'static str> {
     match paren {
@@ -907,7 +907,7 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
         if result.lisp_vline_symbols_enabled {
             on_quote(result);
         }
-    } else if ch == TILDE {
+    } else if ch == GRAVE {
         on_lquote(result);
     } else if ch == result.comment_char {
         on_comment_char(result);
@@ -919,7 +919,7 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
         on_newline(result);
     }
 
-    if result.is_in_str && ch != TILDE {
+    if result.is_in_str && ch != GRAVE {
         result.str_started = true;
         result.quote_close_delim.clear();
     }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -637,24 +637,6 @@ fn is_closable<'a>(result: &State<'a>) -> bool {
     return result.is_in_code() && !is_whitespace(result) && ch != "" && !closer;
 }
 
-fn is_valid_quote<'a>(delim: &'a str, ch: &'a str) -> bool {
-    if delim.is_empty() {
-        return true;
-    } else if delim.contains(ch) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-#[cfg(test)]
-#[test]
-fn is_valid_quote_works() {
-    assert!(is_valid_quote("", "`"));
-    assert!(is_valid_quote("`", "`"));
-    assert!(!is_valid_quote("\"", "`"));
-}
-
 
 // {{{1 Advanced operations on characters
 
@@ -837,7 +819,7 @@ fn in_comment_on_quote<'a>(result: &mut State<'a>) {
     }
 }
 fn in_string_on_quote<'a>(result: &mut State<'a>, delim: &'a str) {
-    if is_valid_quote(delim, result.ch) {
+    if delim == result.ch {
         result.context = In::Code;
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,8 @@ pub struct Options {
     #[serde(default = "Options::default_false")]
     pub lisp_vline_symbols: bool,
     #[serde(default = "Options::default_false")]
+    pub lisp_block_comment: bool,
+    #[serde(default = "Options::default_false")]
     pub janet_long_strings: bool,
 }
 

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -419,6 +419,42 @@ pub fn lisp_vline_symbols() {
 }
 
 #[test]
+pub fn lisp_sharp_syntax_backtrack() {
+    let case = Case {
+        text: String::from("(let ((x #(1 2 3))) x)"),
+        result: CaseResult {
+            text: String::from("(let ((x #(1 2 3))) x)"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            lisp_vline_symbols: None,
+            lisp_block_comment: Some(true),
+            janet_long_strings: None,
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "paren",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
 pub fn lisp_block_comment() {
     let case = Case {
         text: String::from("'(#| this #| is |# nested ) comment |# passed through)"),

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -146,6 +146,8 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     lisp_vline_symbols: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    lisp_block_comment: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
 }
 
@@ -279,6 +281,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             cursor_line: None,
             changes: None,
             lisp_vline_symbols: None,
+            lisp_block_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -321,6 +324,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
                 }
             ]),
             lisp_vline_symbols: None,
+            lisp_block_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -363,6 +367,7 @@ pub fn wide_characters() {
                 }
             ]),
             lisp_vline_symbols: None,
+            lisp_block_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -398,6 +403,43 @@ pub fn lisp_vline_symbols() {
             cursor_line: None,
             changes: None,
             lisp_vline_symbols: Some(true),
+            lisp_block_comment: None,
+            janet_long_strings: None,
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "paren",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
+pub fn lisp_block_comment() {
+    let case = Case {
+        text: String::from("'(#| this #| is |# nested ) comment |# passed through)"),
+        result: CaseResult {
+            text: String::from("'(#| this #| is |# nested ) comment |# passed through)"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            lisp_vline_symbols: None,
+            lisp_block_comment: Some(true),
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -433,6 +475,7 @@ pub fn janet_long_strings() {
             cursor_line: None,
             changes: None,
             lisp_vline_symbols: None,
+            lisp_block_comment: None,
             janet_long_strings: Some(true),
             prev_cursor_x: None,
             prev_cursor_line: None


### PR DESCRIPTION
Closes #66 
~~(This PL is built on top of #79, so please merge #79, if it is okay, before this.)~~

Scheme and Common Lisp support nested block comment:
```lisp
#| depth 1 comment started
    #| depth 2 comment |#
    here is still in comment of depth 1
|#
```
This PL enables parinfer-rust to ignore parens inside the nested block comment.

For doing so, I did a bit of refactoring for function `on_char()` and now it dispatches depending not only on char but also on parser context (i.e., reading code, reading comment, reading string, reading Janet long string, etc.) ~~It works fine for me practically but introduces a failing test case:~~
```
test indent_mode ... FAILED
test smart_mode ... ok

failures:

---- indent_mode stdout ----
thread 'indent_mode' panicked at 'assertion failed: `(left == right)`
  left: `"(let [a 1] ;\n  ret)"`,
 right: `String("(let [a 1]) ;\n  ret")`: case 538: text', tests/cases.rs:34:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    indent_mode

test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```
~~Looks like related to JSON serialization. @eraserhd Could you kindly give me any suggestion to fix this if you have time and if interested in this PL?~~**Fixed!**