### PR TITLE
Add option to support Scheme S-expression comment

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
 * More support for Common Lisp and Scheme:
   - `|Enclosed symbols|`
   - `#|Block comments|#`
+  - `#;(S-expression comments)`
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:parinfer_lisp_block_comment')
   let g:parinfer_lisp_block_comment = 0
 endif
+if !exists('g:parinfer_scheme_sexp_comment')
+  let g:parinfer_scheme_sexp_comment = 0
+endif
 if !exists('g:parinfer_janet_long_strings')
   let g:parinfer_janet_long_strings = 0
 endif
@@ -48,6 +51,9 @@ au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_lisp_vline_symbols =
 " Common Lisp and Scheme: ignore parens in block comments
 au BufNewFile,BufRead *.lsp,*.lisp,*.cl,*.L,sbclrc,.sbclrc let b:parinfer_lisp_block_comment = 1
 au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_lisp_block_comment = 1
+
+" Scheme (SRFI-62): S-expression comment
+au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_scheme_sexp_comment = 1
 
 " Comment settings
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
@@ -169,6 +175,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_lisp_block_comment')
     let b:parinfer_lisp_block_comment = g:parinfer_lisp_block_comment
   endif
+  if !exists('b:parinfer_scheme_sexp_comment')
+    let b:parinfer_scheme_sexp_comment = g:parinfer_scheme_sexp_comment
+  endif
   if !exists('b:parinfer_janet_long_strings')
     let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif
@@ -184,6 +193,7 @@ function! s:process_buffer() abort
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
                                  \ "lispVlineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
                                  \ "lispBlockComment": b:parinfer_lisp_block_comment ? v:true : v:false,
+                                 \ "schemeSexpComment": b:parinfer_scheme_sexp_comment ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -108,6 +108,7 @@ impl Options {
                         selection_start_line: None,
                         lisp_vline_symbols: false,
                         lisp_block_comment: false,
+                        scheme_sexp_comment: false,
                         janet_long_strings: false
                     }
                 })
@@ -139,6 +140,7 @@ impl Options {
                         selection_start_line: None,
                         lisp_vline_symbols: false,
                         lisp_block_comment: false,
+                        scheme_sexp_comment: false,
                         janet_long_strings: false
                     }
                 })

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -125,6 +125,7 @@ fn make_option() -> Result<Options> {
     comment_char: ';',
     lisp_vline_symbols: false,
     lisp_block_comment: false,
+    scheme_sexp_comment: false,
     janet_long_strings: false,
   })
 }
@@ -158,6 +159,7 @@ fn new_options(
     comment_char: ';',
     lisp_vline_symbols: false,
     lisp_block_comment: false,
+    scheme_sexp_comment: false,
     janet_long_strings: false,
   })
 }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -236,6 +236,7 @@ struct State<'a> {
     lisp_vline_symbols_enabled: bool,
     lisp_reader_syntax_enabled: bool,
     lisp_block_comment_enabled: bool,
+    scheme_sexp_comment_enabled: bool,
     janet_long_strings_enabled: bool,
 
     quote_danger: bool,
@@ -276,7 +277,10 @@ fn get_initial_result<'a>(
     mode: Mode,
     smart: bool,
 ) -> State<'a> {
-    let lisp_reader_syntax_enabled = options.lisp_block_comment;
+    let lisp_reader_syntax_enabled = [
+        options.lisp_block_comment,
+        options.scheme_sexp_comment,
+    ].iter().any(|is_true| *is_true);
 
     State {
         mode: mode,
@@ -321,6 +325,7 @@ fn get_initial_result<'a>(
         lisp_vline_symbols_enabled: options.lisp_vline_symbols,
         lisp_reader_syntax_enabled,
         lisp_block_comment_enabled: options.lisp_block_comment,
+        scheme_sexp_comment_enabled: options.scheme_sexp_comment,
         janet_long_strings_enabled: options.janet_long_strings,
 
         quote_danger: false,
@@ -872,6 +877,9 @@ fn in_code_on_nsign<'a>(result: &mut State<'a>) {
 fn in_lisp_reader_syntax_on_vline<'a>(result: &mut State<'a>) {
     result.context = In::LispBlockComment { depth: 1 };
 }
+fn in_lisp_reader_syntax_on_semicolon<'a>(result: &mut State<'a>) {
+    result.context = In::Code;
+}
 
 fn in_lisp_block_comment_pre_on_vline<'a>(result: &mut State<'a>, depth: usize) {
     result.context = In::LispBlockComment { depth: depth + 1 };
@@ -976,6 +984,7 @@ fn on_context<'a>(result: &mut State<'a>) -> Result<()> {
         In::LispReaderSyntax => {
             match ch {
                 VERTICAL_LINE if result.lisp_block_comment_enabled => in_lisp_reader_syntax_on_vline(result),
+                ";" if result.scheme_sexp_comment_enabled => in_lisp_reader_syntax_on_semicolon(result),
                 _ => {
                     // Backtrack!
                     result.context = In::Code;

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,8 @@ pub struct Options {
     #[serde(default = "Options::default_false")]
     pub lisp_block_comment: bool,
     #[serde(default = "Options::default_false")]
+    pub scheme_sexp_comment: bool,
+    #[serde(default = "Options::default_false")]
     pub janet_long_strings: bool,
 }
 

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -148,6 +148,8 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     lisp_block_comment: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    scheme_sexp_comment: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
 }
 
@@ -282,6 +284,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comment: None,
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -325,6 +328,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
             ]),
             lisp_vline_symbols: None,
             lisp_block_comment: None,
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -368,6 +372,7 @@ pub fn wide_characters() {
             ]),
             lisp_vline_symbols: None,
             lisp_block_comment: None,
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -404,6 +409,7 @@ pub fn lisp_vline_symbols() {
             changes: None,
             lisp_vline_symbols: Some(true),
             lisp_block_comment: None,
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -440,6 +446,7 @@ pub fn lisp_sharp_syntax_backtrack() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comment: Some(true),
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -476,6 +483,7 @@ pub fn lisp_block_comment() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comment: Some(true),
+            scheme_sexp_comment: None,
             janet_long_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
@@ -483,6 +491,43 @@ pub fn lisp_block_comment() {
     };
     let input = json!({
         "mode": "paren",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
+pub fn scheme_sexp_comment() {
+    let case = Case {
+        text: String::from("'(#; (ignored here) not ignored"),
+        result: CaseResult {
+            text: String::from("'(#; (ignored here) not ignored)"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            lisp_vline_symbols: None,
+            lisp_block_comment: None,
+            scheme_sexp_comment: Some(true),
+            janet_long_strings: None,
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "indent",
         "text": &case.text,
         "options": &case.options
     }).to_string();
@@ -512,6 +557,7 @@ pub fn janet_long_strings() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comment: None,
+            scheme_sexp_comment: None,
             janet_long_strings: Some(true),
             prev_cursor_x: None,
             prev_cursor_line: None


### PR DESCRIPTION
Another support for Scheme.

In Scheme, reader syntax `#;` comments out one following S-expression. So,
```
'(here is #; (this form is comment) in code)
```
is evaluated to
```
(here is in code)
```
However, parinfer-rust recognizes `;  (this form is comment) in code)` as comment.
This PL enables parinfer-rust to handle it correctly.