### PR TITLE
Skip processing if buffer not modifiable

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -168,7 +168,7 @@ function! s:enter_buffer() abort
 endfunction
 
 function! s:process_buffer() abort
-  if !g:parinfer_enabled || &paste
+  if !g:parinfer_enabled || &paste || !&modifiable
     return
   endif
   if !exists('b:parinfer_last_changedtick')


### PR DESCRIPTION
Currently we have no option to prevent parinfer (vim) from modifying newly opened buffer, which brings problems, see #43.

By skipping non-modifiable buffer, user can set specific buffers non-modiflable to stop parinfer.


## Usage Example

To avoid changing jar source code under `.m2/repository/`:

`autocmd BufReadCmd zipfile:*/* setlocal nomodifiable`

(Vim's built-in zip plugin will treat jar as "zipfile" buffer)