### PR TITLE
Support Guile's block comment syntax

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
   - `|Enclosed symbols|`
   - `#|Block comments|#`
   - `#;(S-expression comments)`
+* Support for Guile's `#!block comments!#`
 
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:parinfer_lisp_block_comments')
   let g:parinfer_lisp_block_comments = 0
 endif
+if !exists('g:parinfer_guile_block_comments')
+  let g:parinfer_guile_block_comments = 0
+endif
 if !exists('g:parinfer_scheme_sexp_comments')
   let g:parinfer_scheme_sexp_comments = 0
 endif
@@ -183,6 +186,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_lisp_block_comments')
     let b:parinfer_lisp_block_comments = g:parinfer_lisp_block_comments
   endif
+  if !exists('b:parinfer_guile_block_comments')
+    let b:parinfer_guile_block_comments = g:parinfer_guile_block_comments
+  endif
   if !exists('b:parinfer_scheme_sexp_comments')
     let b:parinfer_scheme_sexp_comments = g:parinfer_scheme_sexp_comments
   endif
@@ -201,6 +207,7 @@ function! s:process_buffer() abort
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
                                  \ "lispVlineSymbols": b:parinfer_lisp_vline_symbols ? v:true : v:false,
                                  \ "lispBlockComments": b:parinfer_lisp_block_comments ? v:true : v:false,
+                                 \ "guileBlockComments": b:parinfer_guile_block_comments ? v:true : v:false,
                                  \ "schemeSexpComments": b:parinfer_scheme_sexp_comments ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -125,6 +125,7 @@ fn make_option() -> Result<Options> {
     comment_char: ';',
     lisp_vline_symbols: false,
     lisp_block_comments: false,
+    guile_block_comments: false,
     scheme_sexp_comments: false,
     janet_long_strings: false,
   })
@@ -159,6 +160,7 @@ fn new_options(
     comment_char: ';',
     lisp_vline_symbols: false,
     lisp_block_comments: false,
+    guile_block_comments: false,
     scheme_sexp_comments: false,
     janet_long_strings: false,
   })

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,8 @@ pub struct Options {
     #[serde(default = "Options::default_false")]
     pub lisp_block_comments: bool,
     #[serde(default = "Options::default_false")]
+    pub guile_block_comments: bool,
+    #[serde(default = "Options::default_false")]
     pub scheme_sexp_comments: bool,
     #[serde(default = "Options::default_false")]
     pub janet_long_strings: bool,

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -148,6 +148,8 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     lisp_block_comments: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    guile_block_comments: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     scheme_sexp_comments: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
@@ -284,6 +286,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -328,6 +331,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
             ]),
             lisp_vline_symbols: None,
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -372,6 +376,7 @@ pub fn wide_characters() {
             ]),
             lisp_vline_symbols: None,
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -409,6 +414,7 @@ pub fn lisp_vline_symbols() {
             changes: None,
             lisp_vline_symbols: Some(true),
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -446,6 +452,7 @@ pub fn lisp_sharp_syntax_backtrack() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comments: Some(true),
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -483,6 +490,7 @@ pub fn lisp_block_comments() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comments: Some(true),
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -491,6 +499,44 @@ pub fn lisp_block_comments() {
     };
     let input = json!({
         "mode": "paren",
+        "text": &case.text,
+        "options": &case.options
+    }).to_string();
+    let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+    case.check2(answer);
+}
+
+#[test]
+pub fn guile_block_comments() {
+    let case = Case {
+        text: String::from("#!/bin/guile -s \\\n-e main -s\n!#\n(display\n'hello)"),
+        result: CaseResult {
+            text: String::from("#!/bin/guile -s \\\n-e main -s\n!#\n(display)\n'hello"),
+            success: true,
+            error: None,
+            cursor_x: None,
+            cursor_line: None,
+            tab_stops: None,
+            paren_trails: None
+        },
+        source: Source {
+            line_no: 0
+        },
+        options: Options {
+            cursor_x: None,
+            cursor_line: None,
+            changes: None,
+            lisp_vline_symbols: None,
+            lisp_block_comments: None,
+            guile_block_comments: Some(true),
+            scheme_sexp_comments: None,
+            janet_long_strings: None,
+            prev_cursor_x: None,
+            prev_cursor_line: None
+        }
+    };
+    let input = json!({
+        "mode": "indent",
         "text": &case.text,
         "options": &case.options
     }).to_string();
@@ -520,6 +566,7 @@ pub fn scheme_sexp_comments() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: Some(true),
             janet_long_strings: None,
             prev_cursor_x: None,
@@ -557,6 +604,7 @@ pub fn janet_long_strings() {
             changes: None,
             lisp_vline_symbols: None,
             lisp_block_comments: None,
+            guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: Some(true),
             prev_cursor_x: None,


### PR DESCRIPTION
Fix #100

Guile's `#!!#` is not special to shebang. It is another syntax of block comment like `#||#` but cannot be nested. See [Guile manual](https://www.gnu.org/software/guile/manual/html_node/Block-Comments.html).
Although we need to support first-line shebang as well, I'd like to focus on Guile in this PL.