### PR TITLE
Make emacs dependency optional

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,12 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
   - `#;(S-expression comments)`
 * Support for Guile's `#!block comments!#`
 
+=== Emacs
+
+* Compilation for Emacs is now optional. To enable it, run
+`cargo build --release --features emacs`
+
+
 https://github.com/eraserhd/parinfer-rust/compare/v0.4.2...v0.4.3[0.4.3]
 ------------------------------------------------------------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path =  "src/main.rs"
 [dependencies]
 getopts = "0.2"
 libc = "0.2.39"
-emacs = "0.16.2"
 serde = "1.0"
+emacs = {version = "0.16.2", optional = true}
 serde_json = "1.0"
 serde_derive = "1.0"
 unicode-segmentation = "1.1.0"

--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,7 @@ Dependencies:
 * https://www.rust-lang.org/en-US/install.html[rust] >= 1.36
 * `clang` and `libclang-dev` packages or equivalent for your OS
 
+
 === Stand-alone CLI
 
 If you just want to run `parinfer-rust` from the command-line:
@@ -25,6 +26,11 @@ If you just want to run `parinfer-rust` from the command-line:
 ....
 $ cargo build --release
 $ cargo install
+....
+
+If you use emacs add the corresponding feature flag during compilation
+....
+$ cargo build --release --features emacs
 ....
 
 === Vim and Neovim

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod types;
 mod changes;
 
 #[macro_use]
+#[cfg(feature = "emacs")]
 extern crate emacs;
 // Native-specific stuff
 
@@ -28,9 +29,11 @@ pub use c_wrapper::run_parinfer;
 pub use c_wrapper::INITIALIZED;
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "emacs")]
 mod emacs_wrapper;
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "emacs")]
 pub use emacs_wrapper::init;
 
 // WebAssembly-specific stuff


### PR DESCRIPTION
The emacs dependency is pretty big and requires some C libraries to be
installed (it's a pretty big hassle for some people) so i think it's
better to make the dependency optional.