### PR TITLE
Add yuck filetype, allow custom string-delimiters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,9 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
 
 === Added
 
+* Added support for [Yuck](https://github.com/elkowar/eww)
+* String delimiters can now be explicitly configured with the 
+  `string_delimiters` option.
 * Added -l, --language LANG option to easily specify language defaults.
 * The user can now set the character used to denote comments. The
   character can be set on a global or per-buffer basis (using

--- a/README.adoc
+++ b/README.adoc
@@ -208,6 +208,7 @@ This wouldn’t be possible without the work of others:
 * Justin Barclay - Emacs module.
 * Michael Camilleri - User-defined comments.
 * Mitsuhiro Nakamura - Support for Common Lisp and Scheme.
+* ElKowar - User-defined string-delimiters and support for Yuck.
 
 == License
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -10,6 +10,9 @@ endif
 if !exists('g:parinfer_comment_char')
   let g:parinfer_comment_char = ";"
 endif
+if !exists('g:parinfer_string_delimiters')
+  let g:parinfer_string_delimiters = ['"']
+endif
 if !exists('g:parinfer_lisp_vline_symbols')
   let g:parinfer_lisp_vline_symbols = 0
 endif
@@ -64,6 +67,9 @@ au BufNewFile,BufRead *.scm,*.sld,*.ss,*.rkt let b:parinfer_scheme_sexp_comments
 
 " Comment settings
 au BufNewFile,BufRead *.janet let b:parinfer_comment_char = "#"
+
+" Quote settings
+au BufNewFile,BufRead *.yuck let b:parinfer_string_delimiters = ['"', "'", "`"]
 
 " Long strings settings
 au BufNewFile,BufRead *.janet let b:parinfer_janet_long_strings = 1
@@ -180,6 +186,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_comment_char')
     let b:parinfer_comment_char = g:parinfer_comment_char
   endif
+  if !exists('b:parinfer_string_delimiters')
+    let b:parinfer_string_delimiters = g:parinfer_string_delimiters
+  endif
   if !exists('b:parinfer_lisp_vline_symbols')
     let b:parinfer_lisp_vline_symbols = g:parinfer_lisp_vline_symbols
   endif
@@ -202,6 +211,7 @@ function! s:process_buffer() abort
     let l:request = { "mode": g:parinfer_mode,
                     \ "text": l:orig_text,
                     \ "options": { "commentChar": b:parinfer_comment_char,
+                                 \ "stringDelimiters": b:parinfer_string_delimiters,
                                  \ "cursorX": l:cursor[2],
                                  \ "cursorLine": l:cursor[1],
                                  \ "forceBalance": g:parinfer_force_balance ? v:true : v:false,
@@ -281,11 +291,11 @@ function! s:initialize_buffer() abort
 endfunction
 
 augroup Parinfer
-  autocmd FileType clojure,scheme,lisp,racket,hy,fennel,janet,carp,wast call <SID>initialize_buffer()
+  autocmd FileType clojure,scheme,lisp,racket,hy,fennel,janet,carp,wast,yuck call <SID>initialize_buffer()
 augroup END
 
 " Handle the case where parinfer was lazy-loaded
-if (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy' || &filetype ==? 'fennel' || &filetype ==? 'janet' || &filetype ==? 'carp' || &filetype ==? 'wast')
+if (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy' || &filetype ==? 'fennel' || &filetype ==? 'janet' || &filetype ==? 'carp' || &filetype ==? 'wast' || &filetype ==? 'yuck')
   call <SID>initialize_buffer()
 endif
 

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -67,6 +67,7 @@ const SCHEME_SEXP_COMMENTS : YesNoDefaultOption = YesNoDefaultOption {
 fn options() -> getopts::Options {
     let mut options = getopts::Options::new();
     options.optopt(  ""    , "comment-char"         , "(default: ';')", "CC");
+    options.optopt(  ""    , "string-delimiters"    , "(default: '\"')", "DELIM");
     options.optflag("h"    , "help"                 , "show this help message");
     options.optopt( ""     , "input-format"         , "'json', 'text' (default: 'text')", "FMT");
     GUILE_BLOCK_COMMENTS_OPTION.add(&mut options);
@@ -203,6 +204,15 @@ impl Options {
         }
     }
 
+    fn string_delimiters(&self) -> Vec<String> {
+        let delims = self.matches.opt_strs("string-delimiters");
+        if delims.is_empty() {
+            vec!["\"".to_string()]
+        } else {
+            delims
+        }
+    }
+
     fn invertible_flag(&self, name: &str) -> Option<bool> {
         if self.matches.opt_present(name) {
             Some(true)
@@ -258,6 +268,7 @@ impl Options {
                         force_balance: false,
                         return_parens: false,
                         comment_char: char::from(self.comment_char()),
+                        string_delimiters: self.string_delimiters(),
                         partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols: self.lisp_vline_symbols().unwrap_or(lisp_vline_symbols),
@@ -298,6 +309,7 @@ impl Options {
                         force_balance: false,
                         return_parens: false,
                         comment_char: char::from(self.comment_char()),
+                        string_delimiters: self.string_delimiters(),
                         partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols,

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,8 @@ pub struct Options {
     pub return_parens: bool,
     #[serde(default = "Options::default_comment")]
     pub comment_char: char,
+    #[serde(default = "Options::default_string_delimiters")]
+    pub string_delimiters: Vec<String>,
     #[serde(default = "Options::default_false")]
     pub lisp_vline_symbols: bool,
     #[serde(default = "Options::default_false")]
@@ -60,6 +62,9 @@ impl Options {
 
     fn default_comment() -> char {
         ';'
+    }
+    fn default_string_delimiters() -> Vec<String> {
+        vec!["\"".to_string()]
     }
 }
 


### PR DESCRIPTION
This PR adds filetype support for yuck, the new configuration language for [eww](https://github.com/elkowar/eww), as discussed in #107.

As yuck allows for multiple different characters to be used as string delimiters,
most notably `'` as well as `` ` ``, adding full support for yuck means that these need to be seen as strings.

Instead of just opting for a "yuck_strings" option, I decided to add a simple "string-delimiters" option instead.
This option works similarly to the `comment-char`. A custom set of delimiters can be provided in the options object / CLI.

If this more generic implementation is for some reason not desired, I'd be happy to switch it to use a simpler `yuck_strings` option.
