### PR TITLE
Add dune support in vim plugin

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ https://github.com/eraserhd/parinfer-rust/compare/v0.4.3...HEAD[Unreleased]
 * Vim errors when opening an unmodifiable buffer.
 * Fix of E523 regression (often triggered by using `.`), because Vim
   changed the error to E578
+* Add support for [Dune](https://github.com/ocaml/dune)
 
 === Added
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -291,11 +291,11 @@ function! s:initialize_buffer() abort
 endfunction
 
 augroup Parinfer
-  autocmd FileType clojure,scheme,lisp,racket,hy,fennel,janet,carp,wast,yuck call <SID>initialize_buffer()
+  autocmd FileType clojure,scheme,lisp,racket,hy,fennel,janet,carp,wast,yuck,dune call <SID>initialize_buffer()
 augroup END
 
 " Handle the case where parinfer was lazy-loaded
-if (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy' || &filetype ==? 'fennel' || &filetype ==? 'janet' || &filetype ==? 'carp' || &filetype ==? 'wast' || &filetype ==? 'yuck')
+if (&filetype ==? 'clojure' || &filetype ==? 'scheme' || &filetype ==? 'lisp' || &filetype ==? 'racket' || &filetype ==? 'hy' || &filetype ==? 'fennel' || &filetype ==? 'janet' || &filetype ==? 'carp' || &filetype ==? 'wast' || &filetype ==? 'yuck' || &filetype ==? 'dune')
   call <SID>initialize_buffer()
 endif
 


### PR DESCRIPTION
Very simple addition to the vim plugin to enable support for [dune](https://github.com/ocaml/dune)

The clojure defaults in the rust code work nicely enough, so no changes needed there. Let me know if there's anything else you'd like to see