### PR TITLE
Fix Vim E565 error when creating an empty map, vector or list

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -237,7 +237,7 @@ function! s:process_buffer() abort
         silent! undojoin
         try
           call setline(l:changed[0]+1, l:lines[l:changed[0]:l:changed[-1]])
-        catch /E5\(23\|78\):/ " not allowed here / not allowed to change text here
+        catch /E5\(23\|78\|65\):/ " not allowed here / not allowed to change text here / not allowed to chnage text or change window
           " If an event doesn't allow us to modify the buffer, that's OK.
           " Usually another event will happen before a redraw.
           call s:log('not-allowed-here', {})


### PR DESCRIPTION
Same as https://github.com/eraserhd/parinfer-rust/issues/85 but with error E565.

This one happened since few weeks ago and is a real pain when writing code. So far the change involved in that PR allows me to continue editing Clojure code without stopping me in the middle.