### PR TITLE
chore(nix): remove the need to manually update cargoSha256

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -5,7 +5,9 @@ rustPlatform.buildRustPackage rec {
   version = "0.4.3";
 
   src = ./.;
-  cargoSha256 = "0rddfxbrf20xdgjn6jc7l30wj844vk3cb8y10rp0fzs2ccgpx6r3";
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
   buildInputs = [
     llvmPackages.libclang


### PR DESCRIPTION
This removes the manual specification of `cargoSha256`, and replaces it by specifying [`cargoLock.lockFile`](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file) instead. This removes the need to manually update `cargoSha256`; Cargo.lock can be updated without fear of the Nix build breaking.

(This also fixes the Nix build breaking after the last update of Cargo.lock.)