### PR TITLE
Add support for hy bracket strings

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -28,6 +28,9 @@ endif
 if !exists('g:parinfer_janet_long_strings')
   let g:parinfer_janet_long_strings = 0
 endif
+if !exists('g:parinfer_hy_bracket_strings')
+  let g:parinfer_hy_bracket_strings = 0
+endif
 
 " Needs to be outside function because we want <sfile> to be the location of this file,
 " not where it is getting called from.
@@ -73,6 +76,7 @@ au BufNewFile,BufRead *.yuck let b:parinfer_string_delimiters = ['"', "'", "`"]
 
 " Long strings settings
 au BufNewFile,BufRead *.janet let b:parinfer_janet_long_strings = 1
+au BufNewFile,BufRead *.hy let b:parinfer_hy_bracket_strings = 1
 
 " Logging {{{1
 
@@ -204,6 +208,9 @@ function! s:process_buffer() abort
   if !exists('b:parinfer_janet_long_strings')
     let b:parinfer_janet_long_strings = g:parinfer_janet_long_strings
   endif
+  if !exists('b:parinfer_hy_bracket_strings')
+    let b:parinfer_hy_bracket_strings = g:parinfer_hy_bracket_strings
+  endif
   if b:parinfer_last_changedtick != b:changedtick
     let l:cursor = s:get_cursor_position()
     let l:orig_lines = getline(1,'$')
@@ -220,6 +227,7 @@ function! s:process_buffer() abort
                                  \ "guileBlockComments": b:parinfer_guile_block_comments ? v:true : v:false,
                                  \ "schemeSexpComments": b:parinfer_scheme_sexp_comments ? v:true : v:false,
                                  \ "janetLongStrings": b:parinfer_janet_long_strings ? v:true : v:false,
+                                 \ "hyBracketStrings": b:parinfer_hy_bracket_strings ? v:true : v:false,
                                  \ "prevCursorX": w:parinfer_previous_cursor[2],
                                  \ "prevCursorLine": w:parinfer_previous_cursor[1],
                                  \ "prevText": b:parinfer_previous_text } }

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -129,6 +129,7 @@ fn make_option() -> Result<Options> {
     guile_block_comments: false,
     scheme_sexp_comments: false,
     janet_long_strings: false,
+    hy_bracket_strings: false,
   })
 }
 
@@ -165,6 +166,7 @@ fn new_options(
     guile_block_comments: false,
     scheme_sexp_comments: false,
     janet_long_strings: false,
+    hy_bracket_strings: false,
   })
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,8 @@ pub struct Options {
     pub scheme_sexp_comments: bool,
     #[serde(default = "Options::default_false")]
     pub janet_long_strings: bool,
+    #[serde(default = "Options::default_false")]
+    pub hy_bracket_strings: bool,
 }
 
 impl Options {

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -153,6 +153,8 @@ struct Options {
     scheme_sexp_comments: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hy_bracket_strings: Option<bool>,
 }
 
 
@@ -289,6 +291,7 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -334,6 +337,7 @@ pub fn graphemes_in_changes_are_counted_correctly() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -379,6 +383,7 @@ pub fn wide_characters() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -417,6 +422,7 @@ pub fn lisp_vline_symbols() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -455,6 +461,7 @@ pub fn lisp_sharp_syntax_backtrack() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -493,6 +500,7 @@ pub fn lisp_block_comments() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -531,6 +539,7 @@ pub fn guile_block_comments() {
             guile_block_comments: Some(true),
             scheme_sexp_comments: None,
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -569,6 +578,7 @@ pub fn scheme_sexp_comments() {
             guile_block_comments: None,
             scheme_sexp_comments: Some(true),
             janet_long_strings: None,
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -607,6 +617,7 @@ pub fn janet_long_strings() {
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: Some(true),
+            hy_bracket_strings: None,
             prev_cursor_x: None,
             prev_cursor_line: None
         }
@@ -618,4 +629,46 @@ pub fn janet_long_strings() {
     }).to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
+}
+
+#[test]
+pub fn hy_bracket_strings() {
+    let strings = ["'(#[check[ this #[q[ is ]] a bracket ) comment ]check] passed through)"];
+    for &string in &strings {
+        let case = Case {
+            text: String::from(string),
+            result: CaseResult {
+                text: String::from(string),
+                success: true,
+                error: None,
+                cursor_x: None,
+                cursor_line: None,
+                tab_stops: None,
+                paren_trails: None
+            },
+            source: Source {
+                line_no: 0
+            },
+            options: Options {
+                cursor_x: None,
+                cursor_line: None,
+                changes: None,
+                lisp_vline_symbols: None,
+                lisp_block_comments: None,
+                guile_block_comments: None,
+                scheme_sexp_comments: None,
+                janet_long_strings: None,
+                hy_bracket_strings: Some(true),
+                prev_cursor_x: None,
+                prev_cursor_line: None
+            }
+        };
+        let input = json!({
+            "mode": "paren",
+            "text": &case.text,
+            "options": &case.options
+        }).to_string();
+        let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+        case.check2(answer);
+    }
 }


### PR DESCRIPTION
Adds support for parsing Hy-style bracketed strings:

```hy
(foo #[[ ( test ]]
 bar)

(foo #[arbitrary-tag[ ( test
  (bar ]baz] ]] ]still in string]]]
also in string ]arbitrary-tag]
 bar)
```
