### PR TITLE
Add "defer noload" to kakoune install guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,10 +95,10 @@ Add this to your `+kakrc+`
 
 [source,kak]
 ----
-plug "eraserhd/parinfer-rust" do %{
+plug "eraserhd/parinfer-rust" defer noload do %{
     cargo install --force --path .
 } config %{
-    hook global WinSetOption filetype=(clojure|lisp|scheme|racket) %{
+    hook global WinSetOption filetype=(clojure|lisp|scheme|racket|janet|fennel) %{
         parinfer-enable-window -smart
     }
 }


### PR DESCRIPTION
For some reason, this fixes Janet support #143 
I think it's because filetype is not set early