### PR TITLE
Add installation instructions for lazy.nvim (Neovim plugin manager)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,17 @@ Plug 'eraserhd/parinfer-rust', {'do':
         \ 'nix-shell --run \"cargo build --release \"'}
 ----
 
+==== `+lazy.nvim+`
+
+Add this to your `+init.lua+`:
+
+[source,viml]
+----
+require("lazy").setup({
+  {"eraserhd/parinfer-rust", build = "cargo build --release"}
+})
+----
+
 ==== `+Nix+`
 
 If you are a Nix user using Nix + Home Manager to build your vim plugins, you can add:


### PR DESCRIPTION
Hi!
I have provided the installation instructions for the [lazy.nvim](https://github.com/folke/lazy.nvim) plugin manager.