### PR TITLE
2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "parinfer_rust"
 version = "0.4.3"
 authors = ["Jason Felice <jason.m.felice@gmail.com>"]
+edition = "2021"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/benches/perf.rs
+++ b/benches/perf.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
-extern crate test;
 extern crate parinfer_rust;
+extern crate test;
 
 #[macro_use]
 extern crate serde_json;
@@ -9,21 +9,27 @@ extern crate serde_json;
 use std::ffi::CString;
 use test::Bencher;
 
-const LONG_MAP_WITH_STRINGS : &str = include_str!("perf/long_map_with_strings");
-const REALLY_LONG_FILE : &str = include_str!("perf/really_long_file");
-const REALLY_LONG_FILE_WITH_UNCLOSED_PAREN : &str = include_str!("perf/really_long_file_with_unclosed_paren");
-const REALLY_LONG_FILE_WITH_UNCLOSED_QUOTE : &str = include_str!("perf/really_long_file_with_unclosed_quote");
+const LONG_MAP_WITH_STRINGS: &str = include_str!("perf/long_map_with_strings");
+const REALLY_LONG_FILE: &str = include_str!("perf/really_long_file");
+const REALLY_LONG_FILE_WITH_UNCLOSED_PAREN: &str =
+    include_str!("perf/really_long_file_with_unclosed_paren");
+const REALLY_LONG_FILE_WITH_UNCLOSED_QUOTE: &str =
+    include_str!("perf/really_long_file_with_unclosed_quote");
 
 fn build_case(mode: &str, text: &str) -> CString {
-    CString::new(json!({
-        "mode": mode,
-        "text": text,
-        "options": {
-            "forceBalance": false,
-            "partialResult": false,
-            "returnParens": false
-        }
-    }).to_string()).unwrap()
+    CString::new(
+        json!({
+            "mode": mode,
+            "text": text,
+            "options": {
+                "forceBalance": false,
+                "partialResult": false,
+                "returnParens": false
+            }
+        })
+        .to_string(),
+    )
+    .unwrap()
 }
 
 #[bench]

--- a/src/c_wrapper.rs
+++ b/src/c_wrapper.rs
@@ -1,9 +1,9 @@
-use types::*;
+use super::*;
 use libc::c_char;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::panic;
-use super::*;
+use types::*;
 
 /// On unix, Vim loads and unloads the library for every call. On Mac, and
 /// possibly other unices, each load creates a new tlv key, and there is a
@@ -15,19 +15,23 @@ use super::*;
 /// RTLD_GLOBAL to make extra sure).
 #[cfg(all(unix))]
 mod reference_hack {
-    use std::ptr;
-    use std::ffi::CStr;
-    use libc::{c_void, dladdr, dlerror, dlopen};
     use libc::Dl_info;
+    use libc::{c_void, dladdr, dlerror, dlopen};
+    use std::ffi::CStr;
+    use std::ptr;
 
     pub static mut INITIALIZED: bool = false;
 
     #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig"))]
     mod netbsdlike {
-        use libc::{RTLD_LAZY, RTLD_GLOBAL};
+        use libc::{RTLD_GLOBAL, RTLD_LAZY};
 
-        pub fn first_attempt_flags() -> i32 { RTLD_LAZY|RTLD_GLOBAL }
-        pub fn second_attempt_flags() -> i32 { RTLD_LAZY|RTLD_GLOBAL }
+        pub fn first_attempt_flags() -> i32 {
+            RTLD_LAZY | RTLD_GLOBAL
+        }
+        pub fn second_attempt_flags() -> i32 {
+            RTLD_LAZY | RTLD_GLOBAL
+        }
     }
 
     #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig"))]
@@ -35,10 +39,14 @@ mod reference_hack {
 
     #[cfg(not(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig")))]
     mod default {
-        use libc::{RTLD_LAZY, RTLD_NOLOAD, RTLD_NODELETE, RTLD_GLOBAL};
+        use libc::{RTLD_GLOBAL, RTLD_LAZY, RTLD_NODELETE, RTLD_NOLOAD};
 
-        pub fn first_attempt_flags() -> i32 { RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL|RTLD_NODELETE }
-        pub fn second_attempt_flags() -> i32 { RTLD_LAZY|RTLD_GLOBAL|RTLD_NODELETE }
+        pub fn first_attempt_flags() -> i32 {
+            RTLD_LAZY | RTLD_NOLOAD | RTLD_GLOBAL | RTLD_NODELETE
+        }
+        pub fn second_attempt_flags() -> i32 {
+            RTLD_LAZY | RTLD_GLOBAL | RTLD_NODELETE
+        }
     }
 
     #[cfg(not(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig")))]
@@ -53,7 +61,7 @@ mod reference_hack {
             dli_fname: ptr::null(),
             dli_fbase: ptr::null_mut(),
             dli_sname: ptr::null(),
-            dli_saddr: ptr::null_mut()
+            dli_saddr: ptr::null_mut(),
         };
         let initialize_ptr: *const c_void = initialize as *const c_void;
         if dladdr(initialize_ptr, &mut info) == 0 {
@@ -70,12 +78,16 @@ mod reference_hack {
             if handle == ptr::null_mut() {
                 let error = dlerror();
                 if error == ptr::null_mut() {
-                    panic!("Could not reference parinfer_rust library {:?}.",
-                           CStr::from_ptr(info.dli_fname));
+                    panic!(
+                        "Could not reference parinfer_rust library {:?}.",
+                        CStr::from_ptr(info.dli_fname)
+                    );
                 } else {
-                    panic!("Could not reference parinfer_rust library {:?}: {:?}.",
-                           CStr::from_ptr(info.dli_fname),
-                           CStr::from_ptr(error));
+                    panic!(
+                        "Could not reference parinfer_rust library {:?}: {:?}.",
+                        CStr::from_ptr(info.dli_fname),
+                        CStr::from_ptr(error)
+                    );
                 }
             }
         }
@@ -85,37 +97,39 @@ mod reference_hack {
 
 #[cfg(windows)]
 mod reference_hack {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
     use std::ptr;
-    use std::ffi::{OsString};
-    use std::os::windows::ffi::{OsStringExt};
-    use winapi::um::winnt::{LPCWSTR};
-    use winapi::um::libloaderapi::{ GET_MODULE_HANDLE_EX_FLAG_PIN,
-                                    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                                    GetModuleHandleExW, GetModuleFileNameW};
+    use winapi::um::libloaderapi::{
+        GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GET_MODULE_HANDLE_EX_FLAG_PIN,
+    };
+    use winapi::um::winnt::LPCWSTR;
 
     pub static mut INITIALIZED: bool = false;
 
     pub unsafe fn initialize() {
         let mut out = ptr::null_mut();
-        if GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
-                           initialize as LPCWSTR,
-                           &mut out) == 0 {
+        if GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+            initialize as LPCWSTR,
+            &mut out,
+        ) == 0
+        {
             panic!("Could not pin parinfer_rust DLL.")
-        }
-        else {
+        } else {
             let mut buf = Vec::with_capacity(512);
             let len = GetModuleFileNameW(out, buf.as_mut_ptr(), 512 as u32) as usize;
             if len > 0 {
                 buf.set_len(len);
-                let filename = OsString::from_wide(&buf).into_string().expect("expect a string");
+                let filename = OsString::from_wide(&buf)
+                    .into_string()
+                    .expect("expect a string");
                 if filename.ends_with(".dll") {
-                    ;
+                } else {
+                    panic!("parinfer_rust: reference_hack failed to find DLL.");
                 }
-                else {
-                    panic! ("parinfer_rust: reference_hack failed to find DLL.");
-                }
-            }
-            else {
+            } else {
                 panic!("parinfer_rust: could not get DLL filename");
             }
         }
@@ -126,8 +140,7 @@ mod reference_hack {
 mod reference_hack {
     pub static mut INITIALIZED: bool = true;
 
-    pub fn initialize() {
-    }
+    pub fn initialize() {}
 }
 
 pub use self::reference_hack::INITIALIZED;
@@ -149,7 +162,7 @@ pub unsafe extern "C" fn run_parinfer(json: *const c_char) -> *const c_char {
         Ok(Err(e)) => {
             let out = serde_json::to_string(&Answer::from(e)).unwrap();
             CString::new(out).unwrap()
-        },
+        }
         Err(_) => {
             let out = common_wrapper::panic_result();
             CString::new(out).unwrap()

--- a/src/c_wrapper.rs
+++ b/src/c_wrapper.rs
@@ -13,7 +13,7 @@ use types::*;
 /// Here we reference ourselves and throw the handle away to prevent
 /// ourselves from being unloaded (and also set RTLD_NODELETE and
 /// RTLD_GLOBAL to make extra sure).
-#[cfg(all(unix))]
+#[cfg(unix)]
 mod reference_hack {
     use libc::Dl_info;
     use libc::{c_void, dladdr, dlerror, dlopen};
@@ -73,11 +73,11 @@ mod reference_hack {
         // Mac).  dlerror() is unhelfully NULL at that point, so try to
         // *really* load ourselves, then report if that fails.
         let handle = dlopen(info.dli_fname, first_attempt_flags());
-        if handle == ptr::null_mut() {
+        if handle.is_null() {
             let handle = dlopen(info.dli_fname, second_attempt_flags());
-            if handle == ptr::null_mut() {
+            if handle.is_null() {
                 let error = dlerror();
-                if error == ptr::null_mut() {
+                if error.is_null() {
                     panic!(
                         "Could not reference parinfer_rust library {:?}.",
                         CStr::from_ptr(info.dli_fname)
@@ -151,7 +151,7 @@ unsafe fn unwrap_c_pointers(json: *const c_char) -> Result<CString, Error> {
     Ok(CString::new(response)?)
 }
 
-thread_local!(static BUFFER: RefCell<Option<CString>> = RefCell::new(None));
+thread_local!(static BUFFER: RefCell<Option<CString>> = const { RefCell::new(None) });
 
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]

--- a/src/c_wrapper.rs
+++ b/src/c_wrapper.rs
@@ -22,7 +22,7 @@ mod reference_hack {
 
     pub static mut INITIALIZED: bool = false;
 
-    #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig"))]
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
     mod netbsdlike {
         use libc::{RTLD_GLOBAL, RTLD_LAZY};
 
@@ -34,10 +34,10 @@ mod reference_hack {
         }
     }
 
-    #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig"))]
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
     use self::netbsdlike::*;
 
-    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig")))]
+    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd")))]
     mod default {
         use libc::{RTLD_GLOBAL, RTLD_LAZY, RTLD_NODELETE, RTLD_NOLOAD};
 
@@ -49,7 +49,7 @@ mod reference_hack {
         }
     }
 
-    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd", target_os = "bitrig")))]
+    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd")))]
     use self::default::*;
 
     pub unsafe fn initialize() {

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -24,7 +24,11 @@ pub fn compute_text_changes<'a>(prev_text: &'a str, text: &'a str) -> Vec<Change
         }
     }
 
-    for ((i, pc), (j, c)) in prev_text.char_indices().rev().zip(text.char_indices().rev()) {
+    for ((i, pc), (j, c)) in prev_text
+        .char_indices()
+        .rev()
+        .zip(text.char_indices().rev())
+    {
         if pc != c || i < start_prev || j < start_text {
             end_prev = i + pc.len_utf8();
             end_text = j + c.len_utf8();
@@ -37,7 +41,7 @@ pub fn compute_text_changes<'a>(prev_text: &'a str, text: &'a str) -> Vec<Change
             x,
             line_no,
             old_text: String::from(&prev_text[start_prev..end_prev]),
-            new_text: String::from(&text[start_text..end_text])
+            new_text: String::from(&text[start_text..end_text]),
         }]
     } else {
         vec![]
@@ -48,28 +52,40 @@ pub fn compute_text_changes<'a>(prev_text: &'a str, text: &'a str) -> Vec<Change
 #[test]
 fn compute_text_changes_works() {
     assert!(compute_text_changes("hello", "hello").is_empty());
-    assert_eq!(vec![Change {
-        x: 2,
-        line_no: 0,
-        old_text: String::from("l"),
-        new_text: String::from("x")
-    }], compute_text_changes("hello", "hexlo"));
-    assert_eq!(vec![Change {
-        x: 0,
-        line_no: 1,
-        old_text: String::from("l"),
-        new_text: String::from("x")
-    }], compute_text_changes("he\nllo", "he\nxlo"));
-    assert_eq!(vec![Change {
-        x: 4,
-        line_no: 0,
-        old_text: String::from(""),
-        new_text: String::from("l")
-    }], compute_text_changes("hello", "helllo"));
-    assert_eq!(vec![Change {
-        x: 4,
-        line_no: 0,
-        old_text: String::from("l"),
-        new_text: String::from("")
-    }], compute_text_changes("helllo", "hello"));
+    assert_eq!(
+        vec![Change {
+            x: 2,
+            line_no: 0,
+            old_text: String::from("l"),
+            new_text: String::from("x")
+        }],
+        compute_text_changes("hello", "hexlo")
+    );
+    assert_eq!(
+        vec![Change {
+            x: 0,
+            line_no: 1,
+            old_text: String::from("l"),
+            new_text: String::from("x")
+        }],
+        compute_text_changes("he\nllo", "he\nxlo")
+    );
+    assert_eq!(
+        vec![Change {
+            x: 4,
+            line_no: 0,
+            old_text: String::from(""),
+            new_text: String::from("l")
+        }],
+        compute_text_changes("hello", "helllo")
+    );
+    assert_eq!(
+        vec![Change {
+            x: 4,
+            line_no: 0,
+            old_text: String::from("l"),
+            new_text: String::from("")
+        }],
+        compute_text_changes("helllo", "hello")
+    );
 }

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -1,7 +1,5 @@
 use crate::types;
 use crate::types::*;
-use getopts;
-use serde_json;
 use std::env;
 use std::io;
 use std::io::Read;
@@ -289,11 +287,8 @@ impl Options {
                         prev_text: None,
                         prev_cursor_x: None,
                         prev_cursor_line: None,
-                        force_balance: false,
-                        return_parens: false,
-                        comment_char: char::from(self.comment_char()),
+                        comment_char: self.comment_char(),
                         string_delimiters: self.string_delimiters(),
-                        partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols: self.lisp_vline_symbols().unwrap_or(lisp_vline_symbols),
                         lisp_block_comments: self
@@ -335,11 +330,8 @@ impl Options {
                         prev_cursor_line: env::var("kak_opt_parinfer_previous_cursor_line")
                             .map(|s| s.parse::<LineNumber>().unwrap() - 1)
                             .ok(),
-                        force_balance: false,
-                        return_parens: false,
-                        comment_char: char::from(self.comment_char()),
+                        comment_char: self.comment_char(),
                         string_delimiters: self.string_delimiters(),
-                        partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols,
                         lisp_block_comments,
@@ -381,53 +373,47 @@ mod tests {
         let scheme = for_args(&["--language=scheme"]);
         let janet = for_args(&["--language=janet"]);
 
-        assert_eq!(clojure.options.lisp_vline_symbols, false);
-        assert_eq!(scheme.options.lisp_vline_symbols, true);
+        assert!(!clojure.options.lisp_vline_symbols);
+        assert!(scheme.options.lisp_vline_symbols);
 
-        assert_eq!(clojure.options.janet_long_strings, false);
-        assert_eq!(scheme.options.janet_long_strings, false);
-        assert_eq!(janet.options.janet_long_strings, true);
+        assert!(!clojure.options.janet_long_strings);
+        assert!(!scheme.options.janet_long_strings);
+        assert!(janet.options.janet_long_strings);
     }
 
     #[test]
     fn lisp_vline_symbols() {
-        assert_eq!(for_args(&[]).options.lisp_vline_symbols, false);
-        assert_eq!(
-            for_args(&["--language=lisp"]).options.lisp_vline_symbols,
-            true
+        assert!(!for_args(&[]).options.lisp_vline_symbols);
+        assert!(
+            for_args(&["--language=lisp"]).options.lisp_vline_symbols
         );
-        assert_eq!(
+        assert!(
             for_args(&["--lisp-vline-symbols"])
                 .options
-                .lisp_vline_symbols,
-            true
+                .lisp_vline_symbols
         );
-        assert_eq!(
-            for_args(&["--language=lisp", "--no-lisp-vline-symbols"])
+        assert!(
+            !for_args(&["--language=lisp", "--no-lisp-vline-symbols"])
                 .options
-                .lisp_vline_symbols,
-            false
+                .lisp_vline_symbols
         );
     }
 
     #[test]
     fn lisp_block_comments() {
-        assert_eq!(for_args(&[]).options.lisp_block_comments, false);
-        assert_eq!(
-            for_args(&["--language=lisp"]).options.lisp_block_comments,
-            true
+        assert!(!for_args(&[]).options.lisp_block_comments);
+        assert!(
+            for_args(&["--language=lisp"]).options.lisp_block_comments
         );
-        assert_eq!(
+        assert!(
             for_args(&["--lisp-block-comments"])
                 .options
-                .lisp_block_comments,
-            true
+                .lisp_block_comments
         );
-        assert_eq!(
-            for_args(&["--language=lisp", "--no-lisp-block-comments"])
+        assert!(
+            !for_args(&["--language=lisp", "--no-lisp-block-comments"])
                 .options
-                .lisp_block_comments,
-            false
+                .lisp_block_comments
         );
     }
 }

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -3,8 +3,8 @@ use std::env;
 use std::io;
 use std::io::Read;
 use serde_json;
-use types;
-use types::*;
+use crate::types;
+use crate::types::*;
 
 pub enum InputType {
     Json,

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -1,21 +1,21 @@
+use crate::types;
+use crate::types::*;
 use getopts;
+use serde_json;
 use std::env;
 use std::io;
 use std::io::Read;
-use serde_json;
-use crate::types;
-use crate::types::*;
 
 pub enum InputType {
     Json,
     Kakoune,
-    Text
+    Text,
 }
 
 pub enum OutputType {
     Json,
     Kakoune,
-    Text
+    Text,
 }
 
 enum Language {
@@ -28,55 +28,79 @@ enum Language {
 }
 
 pub struct Options {
-    matches: getopts::Matches
+    matches: getopts::Matches,
 }
 
 struct YesNoDefaultOption {
     name: &'static str,
-    description: &'static str
+    description: &'static str,
 }
 
 impl YesNoDefaultOption {
     fn add(&self, options: &mut getopts::Options) {
         options.optflag("", self.name, self.description);
-        options.optflag("", &format!("no-{}", self.name), &format!("do not {}", self.description));
+        options.optflag(
+            "",
+            &format!("no-{}", self.name),
+            &format!("do not {}", self.description),
+        );
     }
 }
 
-const JANET_LONG_STRINGS_OPTION : YesNoDefaultOption = YesNoDefaultOption {
+const JANET_LONG_STRINGS_OPTION: YesNoDefaultOption = YesNoDefaultOption {
     name: "janet-long-strings",
     description: "recognize ``` janet-style long strings ```",
 };
-const LISP_BLOCK_COMMENTS_OPTION : YesNoDefaultOption = YesNoDefaultOption {
+const LISP_BLOCK_COMMENTS_OPTION: YesNoDefaultOption = YesNoDefaultOption {
     name: "lisp-block-comments",
-    description:"recognize #| lisp-style block commments |#.",
+    description: "recognize #| lisp-style block commments |#.",
 };
-const LISP_VLINE_SYMBOLS_OPTION : YesNoDefaultOption = YesNoDefaultOption {
+const LISP_VLINE_SYMBOLS_OPTION: YesNoDefaultOption = YesNoDefaultOption {
     name: "lisp-vline-symbols",
-    description:"recognize |lisp-style vline symbol|s.",
+    description: "recognize |lisp-style vline symbol|s.",
 };
-const GUILE_BLOCK_COMMENTS_OPTION : YesNoDefaultOption = YesNoDefaultOption {
+const GUILE_BLOCK_COMMENTS_OPTION: YesNoDefaultOption = YesNoDefaultOption {
     name: "guile-block-comments",
     description: "recognize #!/guile/block/comments \\n!# )",
 };
-const SCHEME_SEXP_COMMENTS : YesNoDefaultOption = YesNoDefaultOption {
+const SCHEME_SEXP_COMMENTS: YesNoDefaultOption = YesNoDefaultOption {
     name: "scheme-sexp-comments",
     description: "recognize #;( scheme sexp comments )",
 };
 
 fn options() -> getopts::Options {
     let mut options = getopts::Options::new();
-    options.optopt(  ""    , "comment-char"         , "(default: ';')", "CC");
-    options.optopt(  ""    , "string-delimiters"    , "(default: '\"')", "DELIM");
-    options.optflag("h"    , "help"                 , "show this help message");
-    options.optopt( ""     , "input-format"         , "'json', 'text' (default: 'text')", "FMT");
+    options.optopt("", "comment-char", "(default: ';')", "CC");
+    options.optopt("", "string-delimiters", "(default: '\"')", "DELIM");
+    options.optflag("h", "help", "show this help message");
+    options.optopt(
+        "",
+        "input-format",
+        "'json', 'text' (default: 'text')",
+        "FMT",
+    );
     GUILE_BLOCK_COMMENTS_OPTION.add(&mut options);
     JANET_LONG_STRINGS_OPTION.add(&mut options);
-    options.optopt( "l"    , "language"             , "'clojure', 'janet', 'lisp', 'racket', 'guile', 'scheme' (default: 'clojure')", "LANG");
+    options.optopt(
+        "l",
+        "language",
+        "'clojure', 'janet', 'lisp', 'racket', 'guile', 'scheme' (default: 'clojure')",
+        "LANG",
+    );
     LISP_BLOCK_COMMENTS_OPTION.add(&mut options);
     LISP_VLINE_SYMBOLS_OPTION.add(&mut options);
-    options.optopt( "m"    , "mode"                 , "parinfer mode (indent, paren, or smart) (default: smart)", "MODE");
-    options.optopt( ""     , "output-format"        , "'json', 'kakoune', 'text' (default: 'text')", "FMT");
+    options.optopt(
+        "m",
+        "mode",
+        "parinfer mode (indent, paren, or smart) (default: smart)",
+        "MODE",
+    );
+    options.optopt(
+        "",
+        "output-format",
+        "'json', 'kakoune', 'text' (default: 'text')",
+        "FMT",
+    );
     SCHEME_SEXP_COMMENTS.add(&mut options);
     options
 }
@@ -90,20 +114,20 @@ struct Defaults {
     lisp_block_comments: bool,
     guile_block_comments: bool,
     scheme_sexp_comments: bool,
-    janet_long_strings: bool
+    janet_long_strings: bool,
 }
 
 fn parse_language(language: Option<String>) -> Language {
     match language {
         Some(ref s) if s == "clojure" => Language::Clojure,
-        Some(ref s) if s == "janet"   => Language::Janet,
-        Some(ref s) if s == "lisp"    => Language::Lisp,
-        Some(ref s) if s == "racket"  => Language::Racket,
-        Some(ref s) if s == "guile"   => Language::Guile,
-        Some(ref s) if s == "scheme"  => Language::Scheme,
-        None                          => Language::Clojure,
+        Some(ref s) if s == "janet" => Language::Janet,
+        Some(ref s) if s == "lisp" => Language::Lisp,
+        Some(ref s) if s == "racket" => Language::Racket,
+        Some(ref s) if s == "guile" => Language::Guile,
+        Some(ref s) if s == "scheme" => Language::Scheme,
+        None => Language::Clojure,
         // Unknown language.  Defaults kind of work for most lisps
-        Some(_)                       => Language::Clojure,
+        Some(_) => Language::Clojure,
     }
 }
 
@@ -128,28 +152,28 @@ fn language_defaults(language: Language) -> Defaults {
             lisp_block_comments: true,
             guile_block_comments: false,
             scheme_sexp_comments: false,
-            janet_long_strings: false
+            janet_long_strings: false,
         },
         Language::Racket => Defaults {
             lisp_vline_symbols: true,
             lisp_block_comments: true,
             guile_block_comments: false,
             scheme_sexp_comments: true,
-            janet_long_strings: false
+            janet_long_strings: false,
         },
         Language::Guile => Defaults {
             lisp_vline_symbols: true,
             lisp_block_comments: true,
             guile_block_comments: true,
             scheme_sexp_comments: true,
-            janet_long_strings: false
+            janet_long_strings: false,
         },
         Language::Scheme => Defaults {
             lisp_vline_symbols: true,
             lisp_block_comments: true,
             guile_block_comments: false,
             scheme_sexp_comments: true,
-            janet_long_strings: false
+            janet_long_strings: false,
         },
     }
 }
@@ -158,7 +182,7 @@ impl Options {
     pub fn parse(args: &[String]) -> Result<Options, String> {
         options()
             .parse(args)
-            .map(|m| Options {matches: m})
+            .map(|m| Options { matches: m })
             .map_err(|e| e.to_string())
     }
 
@@ -170,9 +194,9 @@ impl Options {
         match self.matches.opt_str("m") {
             None => "smart",
             Some(ref s) if s == "i" || s == "indent" => "indent",
-            Some(ref s) if s == "p" || s == "paren"  => "paren",
-            Some(ref s) if s == "s" || s == "smart"  => "smart",
-            _ => panic!("invalid mode specified for `-m`")
+            Some(ref s) if s == "p" || s == "paren" => "paren",
+            Some(ref s) if s == "s" || s == "smart" => "smart",
+            _ => panic!("invalid mode specified for `-m`"),
         }
     }
 
@@ -182,7 +206,7 @@ impl Options {
             Some(ref s) if s == "text" => InputType::Text,
             Some(ref s) if s == "json" => InputType::Json,
             Some(ref s) if s == "kakoune" => InputType::Kakoune,
-            Some(ref s) => panic!("unknown input format `{}`", s)
+            Some(ref s) => panic!("unknown input format `{}`", s),
         }
     }
 
@@ -192,15 +216,15 @@ impl Options {
             Some(ref s) if s == "text" => OutputType::Text,
             Some(ref s) if s == "json" => OutputType::Json,
             Some(ref s) if s == "kakoune" => OutputType::Kakoune,
-            Some(ref s) => panic!("unknown output fomrat `{}`", s)
+            Some(ref s) => panic!("unknown output fomrat `{}`", s),
         }
     }
 
     fn comment_char(&self) -> char {
         match self.matches.opt_str("comment-char") {
             None => ';',
-            Some(ref s) if s.chars().count() == 1 =>  s.chars().next().unwrap(),
-            Some(ref _s) => panic!("comment character must be a single character")
+            Some(ref s) if s.chars().count() == 1 => s.chars().next().unwrap(),
+            Some(ref _s) => panic!("comment character must be a single character"),
         }
     }
 
@@ -251,7 +275,7 @@ impl Options {
                     lisp_block_comments,
                     guile_block_comments,
                     scheme_sexp_comments,
-                    janet_long_strings
+                    janet_long_strings,
                 } = language_defaults(parse_language(self.matches.opt_str("language")));
                 let mut text = String::new();
                 input.read_to_string(&mut text)?;
@@ -272,20 +296,26 @@ impl Options {
                         partial_result: false,
                         selection_start_line: None,
                         lisp_vline_symbols: self.lisp_vline_symbols().unwrap_or(lisp_vline_symbols),
-                        lisp_block_comments: self.lisp_block_comments().unwrap_or(lisp_block_comments),
-                        guile_block_comments: self.guile_block_comments().unwrap_or(guile_block_comments),
-                        scheme_sexp_comments: self.scheme_sexp_comments().unwrap_or(scheme_sexp_comments),
+                        lisp_block_comments: self
+                            .lisp_block_comments()
+                            .unwrap_or(lisp_block_comments),
+                        guile_block_comments: self
+                            .guile_block_comments()
+                            .unwrap_or(guile_block_comments),
+                        scheme_sexp_comments: self
+                            .scheme_sexp_comments()
+                            .unwrap_or(scheme_sexp_comments),
                         janet_long_strings: self.janet_long_strings().unwrap_or(janet_long_strings),
-                    }
+                    },
                 })
-            },
+            }
             InputType::Kakoune => {
                 let Defaults {
                     lisp_vline_symbols,
                     lisp_block_comments,
                     guile_block_comments,
                     scheme_sexp_comments,
-                    janet_long_strings
+                    janet_long_strings,
                 } = language_defaults(parse_language(env::var("kak_opt_filetype").ok()));
                 Ok(Request {
                     mode: String::from(self.mode()),
@@ -298,8 +328,7 @@ impl Options {
                         cursor_line: env::var("kak_opt_parinfer_cursor_line")
                             .map(|s| s.parse::<LineNumber>().unwrap() - 1)
                             .ok(),
-                        prev_text: env::var("kak_opt_parinfer_previous_text")
-                            .ok(),
+                        prev_text: env::var("kak_opt_parinfer_previous_text").ok(),
                         prev_cursor_x: env::var("kak_opt_parinfer_previous_cursor_char_column")
                             .map(|s| s.parse::<Column>().unwrap() - 1)
                             .ok(),
@@ -317,14 +346,14 @@ impl Options {
                         guile_block_comments,
                         scheme_sexp_comments,
                         janet_long_strings,
-                    }
+                    },
                 })
-            },
+            }
             InputType::Json => {
                 let mut text = String::new();
                 input.read_to_string(&mut text)?;
                 Ok(serde_json::from_str(&text)?)
-            },
+            }
         }
     }
 }
@@ -363,16 +392,42 @@ mod tests {
     #[test]
     fn lisp_vline_symbols() {
         assert_eq!(for_args(&[]).options.lisp_vline_symbols, false);
-        assert_eq!(for_args(&["--language=lisp"]).options.lisp_vline_symbols, true);
-        assert_eq!(for_args(&["--lisp-vline-symbols"]).options.lisp_vline_symbols, true);
-        assert_eq!(for_args(&["--language=lisp", "--no-lisp-vline-symbols"]).options.lisp_vline_symbols, false);
+        assert_eq!(
+            for_args(&["--language=lisp"]).options.lisp_vline_symbols,
+            true
+        );
+        assert_eq!(
+            for_args(&["--lisp-vline-symbols"])
+                .options
+                .lisp_vline_symbols,
+            true
+        );
+        assert_eq!(
+            for_args(&["--language=lisp", "--no-lisp-vline-symbols"])
+                .options
+                .lisp_vline_symbols,
+            false
+        );
     }
 
     #[test]
     fn lisp_block_comments() {
         assert_eq!(for_args(&[]).options.lisp_block_comments, false);
-        assert_eq!(for_args(&["--language=lisp"]).options.lisp_block_comments, true);
-        assert_eq!(for_args(&["--lisp-block-comments"]).options.lisp_block_comments, true);
-        assert_eq!(for_args(&["--language=lisp", "--no-lisp-block-comments"]).options.lisp_block_comments, false);
+        assert_eq!(
+            for_args(&["--language=lisp"]).options.lisp_block_comments,
+            true
+        );
+        assert_eq!(
+            for_args(&["--lisp-block-comments"])
+                .options
+                .lisp_block_comments,
+            true
+        );
+        assert_eq!(
+            for_args(&["--language=lisp", "--no-lisp-block-comments"])
+                .options
+                .lisp_block_comments,
+            false
+        );
     }
 }

--- a/src/common_wrapper.rs
+++ b/src/common_wrapper.rs
@@ -5,7 +5,7 @@ use types::*;
 pub fn internal_run(json_str: &str) -> Result<String, Error> {
     let request: Request = serde_json::from_str(json_str)?;
     let answer = parinfer::process(&request);
-    Ok(serde_json::to_string(&Answer::from(answer))?)
+    Ok(serde_json::to_string(&answer)?)
 }
 
 pub fn panic_result() -> String {

--- a/src/common_wrapper.rs
+++ b/src/common_wrapper.rs
@@ -24,7 +24,7 @@ pub fn panic_result() -> String {
         cursor_line: None,
         tab_stops: vec![],
         paren_trails: vec![],
-        parens: vec![]
+        parens: vec![],
     };
 
     serde_json::to_string(&answer).unwrap()

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -2,11 +2,7 @@ use super::parinfer::rc_process;
 use emacs::{Env, IntoLisp, Result, Value};
 use types::{Change, Error, Options, Request, SharedRequest, WrappedAnswer};
 
-use std::{fs::OpenOptions,
-          io::Write,
-          convert::TryFrom,
-          cell::RefCell,
-          rc::Rc};
+use std::{cell::RefCell, convert::TryFrom, fs::OpenOptions, io::Write, rc::Rc};
 
 emacs::plugin_is_GPL_compatible!();
 
@@ -14,28 +10,28 @@ emacs::plugin_is_GPL_compatible!();
 // this type conversion directy
 /// A helper function to Option<i64> to Option<usize>
 fn to_usize(value: Option<i64>) -> Option<usize> {
-  match value {
-    Some(item) => match usize::try_from(item) {
-      Ok(new_value) => Some(new_value),
-      Err(_) => None,
-    },
-    None => None,
-  }
+    match value {
+        Some(item) => match usize::try_from(item) {
+            Ok(new_value) => Some(new_value),
+            Err(_) => None,
+        },
+        None => None,
+    }
 }
 
 fn to_i64(value: Option<usize>) -> Option<i64> {
-  match value {
-    Some(item) => match i64::try_from(item) {
-      Ok(new_value) => Some(new_value),
-      Err(_) => None,
-    },
-    None => None,
-  }
+    match value {
+        Some(item) => match i64::try_from(item) {
+            Ok(new_value) => Some(new_value),
+            Err(_) => None,
+        },
+        None => None,
+    }
 }
 
 #[emacs::module(name = "parinfer-rust")]
 pub fn init(_: &Env) -> Result<()> {
-  Ok(())
+    Ok(())
 }
 
 ////////////////////////////////
@@ -93,9 +89,9 @@ type AliasedRequest<'a> = &'a SharedRequest;
 /// (parinfer-rust-execute request)
 /// ```
 fn execute(request: AliasedRequest) -> Result<WrappedAnswer> {
-  let answer = rc_process(&request);
-  let wrapped_answer = unsafe{WrappedAnswer::new(request.clone(), answer)};
-  Ok(wrapped_answer)
+    let answer = rc_process(&request);
+    let wrapped_answer = unsafe { WrappedAnswer::new(request.clone(), answer) };
+    Ok(wrapped_answer)
 }
 ////////////////////////////////
 // options
@@ -111,25 +107,25 @@ fn execute(request: AliasedRequest) -> Result<WrappedAnswer> {
 /// (parinfer-make-option)
 /// ```
 fn make_option() -> Result<Options> {
-  Ok(Options {
-    cursor_x: None,
-    cursor_line: None,
-    prev_cursor_x: None,
-    prev_cursor_line: None,
-    prev_text: None,
-    selection_start_line: None,
-    changes: Vec::new(),
-    partial_result: false,
-    force_balance: false,
-    return_parens: false,
-    comment_char: ';',
-    string_delimiters: vec!["\"".to_string()],
-    lisp_vline_symbols: false,
-    lisp_block_comments: false,
-    guile_block_comments: false,
-    scheme_sexp_comments: false,
-    janet_long_strings: false,
-  })
+    Ok(Options {
+        cursor_x: None,
+        cursor_line: None,
+        prev_cursor_x: None,
+        prev_cursor_line: None,
+        prev_text: None,
+        selection_start_line: None,
+        changes: Vec::new(),
+        partial_result: false,
+        force_balance: false,
+        return_parens: false,
+        comment_char: ';',
+        string_delimiters: vec!["\"".to_string()],
+        lisp_vline_symbols: false,
+        lisp_block_comments: false,
+        guile_block_comments: false,
+        scheme_sexp_comments: false,
+        janet_long_strings: false,
+    })
 }
 
 #[defun(user_ptr, mod_in_name = false)]
@@ -141,31 +137,31 @@ fn make_option() -> Result<Options> {
 /// (parinfer-new-option 1 1 nil options changes)
 /// ```
 fn new_options(
-  cursor_x: Option<i64>,
-  cursor_line: Option<i64>,
-  selection_start_line: Option<i64>,
-  old_options: &Options,
-  changes: &Vec<Change>,
+    cursor_x: Option<i64>,
+    cursor_line: Option<i64>,
+    selection_start_line: Option<i64>,
+    old_options: &Options,
+    changes: &Vec<Change>,
 ) -> Result<Options> {
-  Ok(Options {
-    cursor_x: to_usize(cursor_x),
-    cursor_line: to_usize(cursor_line),
-    prev_cursor_x: old_options.cursor_x,
-    prev_cursor_line: old_options.cursor_line,
-    selection_start_line: to_usize(selection_start_line),
-    changes: changes.clone(),
-    prev_text: None,
-    partial_result: false,
-    force_balance: false,
-    return_parens: false,
-    comment_char: ';',
-    string_delimiters: vec!["\"".to_string()],
-    lisp_vline_symbols: false,
-    lisp_block_comments: false,
-    guile_block_comments: false,
-    scheme_sexp_comments: false,
-    janet_long_strings: false,
-  })
+    Ok(Options {
+        cursor_x: to_usize(cursor_x),
+        cursor_line: to_usize(cursor_line),
+        prev_cursor_x: old_options.cursor_x,
+        prev_cursor_line: old_options.cursor_line,
+        selection_start_line: to_usize(selection_start_line),
+        changes: changes.clone(),
+        prev_text: None,
+        partial_result: false,
+        force_balance: false,
+        return_parens: false,
+        comment_char: ';',
+        string_delimiters: vec!["\"".to_string()],
+        lisp_vline_symbols: false,
+        lisp_block_comments: false,
+        guile_block_comments: false,
+        scheme_sexp_comments: false,
+        janet_long_strings: false,
+    })
 }
 
 #[defun(mod_in_name = false)]
@@ -177,7 +173,7 @@ fn new_options(
 /// (parinfer-print-option options)
 /// ```
 fn print_options<'a>(options: &Options) -> Result<String> {
-  Ok(format!("{:?}", options.clone()).to_string())
+    Ok(format!("{:?}", options.clone()).to_string())
 }
 
 ////////////////////////////////
@@ -193,19 +189,19 @@ fn print_options<'a>(options: &Options) -> Result<String> {
 /// (parinfer-make-changes)
 /// ```
 fn make_changes() -> Result<Vec<Change>> {
-  Ok(Vec::new())
+    Ok(Vec::new())
 }
 #[defun(user_ptr, mod_in_name = false)]
 fn new_change(line_number: i64, x: i64, old_text: String, new_text: String) -> Result<Change> {
-  let line_no = usize::try_from(line_number)?;
-  let new_x = usize::try_from(x)?;
-  let change = Change {
-    x: new_x,
-    line_no,
-    old_text,
-    new_text,
-  };
-  Ok(change)
+    let line_no = usize::try_from(line_number)?;
+    let new_x = usize::try_from(x)?;
+    let change = Change {
+        x: new_x,
+        line_no,
+        old_text,
+        new_text,
+    };
+    Ok(change)
 }
 
 #[defun(mod_in_name = false)]
@@ -217,7 +213,7 @@ fn new_change(line_number: i64, x: i64, old_text: String, new_text: String) -> R
 /// (parinfer-make-changes)
 /// ```
 fn add_change(changes: &mut Vec<Change>, change: &Change) -> Result<()> {
-  Ok(changes.push(change.clone()))
+    Ok(changes.push(change.clone()))
 }
 
 #[defun(mod_in_name = false)]
@@ -229,7 +225,7 @@ fn add_change(changes: &mut Vec<Change>, change: &Change) -> Result<()> {
 /// (parinfer-print-changes changes)
 /// ```
 fn print_changes<'a>(env: &'a Env, changes: &mut Vec<Change>) -> Result<Value<'a>> {
-  format!("{:?}", changes).into_lisp(env)
+    format!("{:?}", changes).into_lisp(env)
 }
 
 ////////////////////////////////
@@ -246,12 +242,12 @@ fn print_changes<'a>(env: &'a Env, changes: &mut Vec<Change>) -> Result<Value<'a
 /// ```
 //
 fn make_request(mode: String, text: String, options: &mut Options) -> Result<SharedRequest> {
-  let request = Request {
-    mode,
-    text,
-    options: options.clone(),
-  };
-  Ok(Rc::new(request))
+    let request = Request {
+        mode,
+        text,
+        options: options.clone(),
+    };
+    Ok(Rc::new(request))
 }
 
 /// Creates a Request from the given mode, current buffer text, and the set of Options
@@ -264,7 +260,7 @@ fn make_request(mode: String, text: String, options: &mut Options) -> Result<Sha
 //
 #[defun(mod_in_name = false)]
 fn print_request(request: AliasedRequest) -> Result<String> {
-  Ok(format!("{:?}", &request).to_string())
+    Ok(format!("{:?}", &request).to_string())
 }
 ////////////////////////////////
 // Answer
@@ -279,34 +275,35 @@ fn print_request(request: AliasedRequest) -> Result<String> {
 /// (parinfer-get-in-answer answer "success")
 /// ```
 fn get_in_answer<'a>(
-  env: &'a Env,
-  answer: &WrappedAnswer,
-  key: Option<String>,
+    env: &'a Env,
+    answer: &WrappedAnswer,
+    key: Option<String>,
 ) -> Result<Value<'a>> {
-  let unwrapped_answer = answer.inner();
-  let query = match key {
-    Some(key) => key,
-    None => return env.message("Missing 'key'"),
-  };
+    let unwrapped_answer = answer.inner();
+    let query = match key {
+        Some(key) => key,
+        None => return env.message("Missing 'key'"),
+    };
 
-  // I only care about some nested structures at the moment, errors,
-  // so leave tab_stops, paren_trails, and parens as unsupported
-  match query.as_ref() {
-    "text" => unwrapped_answer.text.to_string().into_lisp(env),
-    "success" => unwrapped_answer.success.into_lisp(env),
-    "cursor_x" => to_i64(unwrapped_answer.cursor_x).into_lisp(env),
-    "cursor_line" => to_i64(unwrapped_answer.cursor_line).into_lisp(env),
-    "error" => match unwrapped_answer.error.clone() {
-      Some(error) => Ok(RefCell::new(error).into_lisp(env)?),
-      None => ().into_lisp(env),
+    // I only care about some nested structures at the moment, errors,
+    // so leave tab_stops, paren_trails, and parens as unsupported
+    match query.as_ref() {
+        "text" => unwrapped_answer.text.to_string().into_lisp(env),
+        "success" => unwrapped_answer.success.into_lisp(env),
+        "cursor_x" => to_i64(unwrapped_answer.cursor_x).into_lisp(env),
+        "cursor_line" => to_i64(unwrapped_answer.cursor_line).into_lisp(env),
+        "error" => match unwrapped_answer.error.clone() {
+            Some(error) => Ok(RefCell::new(error).into_lisp(env)?),
+            None => ().into_lisp(env),
+        },
+        // "tab_stops"
+        // "paren_trails"
+        // "parens"
+        _ => {
+            env.message(format!("Key '{}' unsupported", query))?;
+            ().into_lisp(env)
+        }
     }
-    // "tab_stops"
-    // "paren_trails"
-    // "parens"
-    _ => {
-      env.message(format!("Key '{}' unsupported", query))?;
-      ().into_lisp(env)},
-  }
 }
 
 #[defun(mod_in_name = false)]
@@ -318,7 +315,7 @@ fn get_in_answer<'a>(
 /// (parinfer-rust-print-answer answer)
 /// ```
 fn print_answer(answer: &WrappedAnswer) -> Result<String> {
-  Ok(format!("{:?}", answer.inner()).to_string())
+    Ok(format!("{:?}", answer.inner()).to_string())
 }
 
 #[defun(mod_in_name = false)]
@@ -329,25 +326,30 @@ fn print_answer(answer: &WrappedAnswer) -> Result<String> {
 /// ```elisp,no_run
 /// (parinfer-rust-debug "/tmp/parinfer.txt" options answer)
 /// ```
-fn debug(env: &Env, filename: String, options: &Options, wrapped_answer: &WrappedAnswer) -> Result<()> {
-  let answer = wrapped_answer.inner();
-  let file = match OpenOptions::new().append(true).create(true).open(&filename) {
-    Ok(file) => file,
-    Err(_) => {
-      env.message(&format!("Unable to open file {}", filename))?;
-      return Ok(());
-    }
-  };
+fn debug(
+    env: &Env,
+    filename: String,
+    options: &Options,
+    wrapped_answer: &WrappedAnswer,
+) -> Result<()> {
+    let answer = wrapped_answer.inner();
+    let file = match OpenOptions::new().append(true).create(true).open(&filename) {
+        Ok(file) => file,
+        Err(_) => {
+            env.message(&format!("Unable to open file {}", filename))?;
+            return Ok(());
+        }
+    };
 
-  match write!(&file, "Options:\n{:?}\nResponse:\n{:?}\n", options, answer) {
-    Ok(_) => {
-      env.message(&format!("Wrote debug information to {}", filename))?;
-    }
-    Err(_) => {
-      env.message(&format!("Unable to write to file {}", filename))?;
-    }
-  };
-  Ok(())
+    match write!(&file, "Options:\n{:?}\nResponse:\n{:?}\n", options, answer) {
+        Ok(_) => {
+            env.message(&format!("Wrote debug information to {}", filename))?;
+        }
+        Err(_) => {
+            env.message(&format!("Unable to write to file {}", filename))?;
+        }
+    };
+    Ok(())
 }
 
 ////////////////////////////////
@@ -362,24 +364,24 @@ fn debug(env: &Env, filename: String, options: &Options, wrapped_answer: &Wrappe
 /// ```elisp,no_run
 /// (parinfer-get-in-error error "message")
 /// ```
-fn get_in_error<'a>(env: &'a Env, error: &Error, key: Option<String>)-> Result<Value<'a>> {
-  let query = match key {
-    Some(key) => key,
-    None => "".to_string(),
-  };
+fn get_in_error<'a>(env: &'a Env, error: &Error, key: Option<String>) -> Result<Value<'a>> {
+    let query = match key {
+        Some(key) => key,
+        None => "".to_string(),
+    };
 
-  match query.as_ref() {
-    "name" => error.name.to_string().into_lisp(env),
-    "message" => error.message.clone().into_lisp(env),
-    "x" => to_i64(Some(error.x)).into_lisp(env),
-    "line_no" => to_i64(Some(error.line_no)).into_lisp(env),
-    "input_x" => to_i64(Some(error.input_x)).into_lisp(env),
-    "input_line_no" => to_i64(Some(error.input_line_no)).into_lisp(env),
-    _ => {
-      env.message(format!("Key '{}' unsupported", query))?; // Can return an error
-      ().into_lisp(env)
+    match query.as_ref() {
+        "name" => error.name.to_string().into_lisp(env),
+        "message" => error.message.clone().into_lisp(env),
+        "x" => to_i64(Some(error.x)).into_lisp(env),
+        "line_no" => to_i64(Some(error.line_no)).into_lisp(env),
+        "input_x" => to_i64(Some(error.input_x)).into_lisp(env),
+        "input_line_no" => to_i64(Some(error.input_line_no)).into_lisp(env),
+        _ => {
+            env.message(format!("Key '{}' unsupported", query))?; // Can return an error
+            ().into_lisp(env)
+        }
     }
-  }
 }
 
 #[defun(mod_in_name = false)]
@@ -390,8 +392,8 @@ fn get_in_error<'a>(env: &'a Env, error: &Error, key: Option<String>)-> Result<V
 /// ```elisp,no_run
 /// (parinfer-rust-print-error error)
 /// ```
-fn print_error(error: &Error) -> Result<String>{
-  Ok(format!("{:?}", error).to_string())
+fn print_error(error: &Error) -> Result<String> {
+    Ok(format!("{:?}", error).to_string())
 }
 
 #[defun(mod_in_name = false)]
@@ -403,5 +405,5 @@ fn print_error(error: &Error) -> Result<String>{
 /// (parinfer-rust-version)
 /// ```
 fn version() -> Result<String> {
-  Ok(env!("CARGO_PKG_VERSION").to_string())
+    Ok(env!("CARGO_PKG_VERSION").to_string())
 }

--- a/src/kakoune.rs
+++ b/src/kakoune.rs
@@ -1,5 +1,5 @@
-use parinfer::chomp_cr;
-use types::*;
+use crate::parinfer::chomp_cr;
+use crate::types::*;
 use std::env;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/kakoune.rs
+++ b/src/kakoune.rs
@@ -74,7 +74,7 @@ pub fn fixes<'a>(from: &'a str, to: &'a str) -> Fixes {
             result
                 .deletions
                 .push(Selection::new(line, 1, line, a_line.chars().count()));
-            if b_line != "" {
+            if !b_line.is_empty() {
                 result.insertions.push(Insertion::new(line, 1, b_line));
             }
         }
@@ -164,7 +164,7 @@ pub fn kakoune_output(request: &Request, answer: Answer) -> (String, i32) {
             "{}\n{}\n{}",
             delete_script(&fixes),
             insert_script(&fixes),
-            cursor_script(&request, &answer)
+            cursor_script(request, &answer)
         );
 
         (script, 0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ extern crate serde_derive;
 extern crate unicode_segmentation;
 extern crate unicode_width;
 
+mod changes;
 mod parinfer;
 mod types;
-mod changes;
 
 #[macro_use]
 #[cfg(feature = "emacs")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ extern crate serde_derive;
 extern crate unicode_segmentation;
 extern crate unicode_width;
 
-
 mod changes;
 mod cli_options;
 mod kakoune;
@@ -25,24 +24,22 @@ use types::*;
 
 fn parse_args() -> cli_options::Options {
     let args: Vec<String> = env::args().collect();
-    cli_options::Options::parse(&args[1..])
-        .expect("failed to parse options")
+    cli_options::Options::parse(&args[1..]).expect("failed to parse options")
 }
 
 fn json_output(_request: &Request, answer: Answer) -> (String, i32) {
     let text = serde_json::to_string(&answer).expect("unable to produce JSON");
     let error_code = if answer.success { 0 } else { 1 };
-    ( text, error_code )
+    (text, error_code)
 }
-
 
 fn text_output(_request: &Request, answer: Answer) -> (String, i32) {
     if answer.success {
-        ( answer.text.into_owned(), 0 )
+        (answer.text.into_owned(), 0)
     } else {
         match answer.error {
-            None => ( String::from("parinfer-rust: unknown error.\n"), 1 ),
-            Some(e) => ( format!("parinfer-rust: {}\n", e.message), 1 )
+            None => (String::from("parinfer-rust: unknown error.\n"), 1),
+            Some(e) => (format!("parinfer-rust: {}\n", e.message), 1),
         }
     }
 }
@@ -52,14 +49,18 @@ pub fn main() {
     if opts.want_help() {
         print!("{}", cli_options::usage());
     } else {
-        let request = opts.request(&mut io::stdin()).expect("unable to parse options");
+        let request = opts
+            .request(&mut io::stdin())
+            .expect("unable to parse options");
         let answer = parinfer::process(&request);
         let (output, error_code) = match opts.output_type() {
             OutputType::Json => json_output(&request, answer),
             OutputType::Kakoune => kakoune_output(&request, answer),
-            OutputType::Text => text_output(&request, answer)
+            OutputType::Text => text_output(&request, answer),
         };
-        io::stdout().write(output.as_bytes()).expect("unable to write output");
+        io::stdout()
+            .write(output.as_bytes())
+            .expect("unable to write output");
         std::process::exit(error_code);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ pub fn main() {
             OutputType::Text => text_output(&request, answer),
         };
         io::stdout()
-            .write(output.as_bytes())
+            .write_all(output.as_bytes())
             .expect("unable to write output");
         std::process::exit(error_code);
     }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -1,10 +1,9 @@
-use super::std;
 use std::collections::HashMap;
 use std::borrow::Cow;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
-use types::*;
-use changes;
+use crate::types::*;
+use crate::changes;
 
 // {{{1 Constants / Predicates
 

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -7,15 +7,15 @@ use unicode_width::UnicodeWidthStr;
 
 // {{{1 Constants / Predicates
 
-const BACKSLASH: &'static str = "\\";
-const BLANK_SPACE: &'static str = " ";
-const DOUBLE_SPACE: &'static str = "  ";
-const VERTICAL_LINE: &'static str = "|";
-const BANG: &'static str = "!";
-const NUMBER_SIGN: &'static str = "#";
-const NEWLINE: &'static str = "\n";
-const TAB: &'static str = "\t";
-const GRAVE: &'static str = "`";
+const BACKSLASH: &str = "\\";
+const BLANK_SPACE: &str = " ";
+const DOUBLE_SPACE: &str = "  ";
+const VERTICAL_LINE: &str = "|";
+const BANG: &str = "!";
+const NUMBER_SIGN: &str = "#";
+const NEWLINE: &str = "\n";
+const TAB: &str = "\t";
+const GRAVE: &str = "`";
 
 fn match_paren(paren: &str) -> Option<&'static str> {
     match paren {
@@ -45,15 +45,15 @@ struct TransformedChange {
     lookup_x: Column,
 }
 
-pub fn chomp_cr<'a>(text: &'a str) -> &'a str {
-    if text.chars().last() == Some('\r') {
+pub fn chomp_cr(text: &str) -> &str {
+    if text.ends_with('\r') {
         &text[0..text.len() - 1]
     } else {
         text
     }
 }
 
-fn split_lines<'a>(text: &'a str) -> Vec<&'a str> {
+fn split_lines(text: &str) -> Vec<&str> {
     text.split('\n').map(chomp_cr).collect()
 }
 
@@ -90,9 +90,7 @@ fn transform_change<'a>(change: &'a Change) -> TransformedChange {
     }
 }
 
-fn transform_changes<'a>(
-    changes: &Vec<Change>,
-) -> HashMap<(LineNumber, Column), TransformedChange> {
+fn transform_changes(changes: &Vec<Change>) -> HashMap<(LineNumber, Column), TransformedChange> {
     let mut lines: HashMap<(LineNumber, Column), TransformedChange> = HashMap::new();
     for change in changes {
         let transformed_change = transform_change(change);
@@ -145,18 +143,12 @@ enum Now {
     Escaped,
 }
 
-impl<'a> State<'a> {
+impl State<'_> {
     fn is_escaping(&self) -> bool {
-        match self.escape {
-            Now::Escaping => true,
-            _ => false,
-        }
+        matches!(self.escape, Now::Escaping)
     }
     fn is_escaped(&self) -> bool {
-        match self.escape {
-            Now::Escaped => true,
-            _ => false,
-        }
+        matches!(self.escape, Now::Escaped)
     }
 }
 
@@ -188,32 +180,25 @@ enum In<'a> {
     },
 }
 
-impl<'a> State<'a> {
+impl State<'_> {
     fn is_in_code(&self) -> bool {
-        match self.context {
-            In::Code => true,
-            In::LispReaderSyntax => true,
-            _ => false,
-        }
+        matches!(self.context, In::Code | In::LispReaderSyntax)
     }
     fn is_in_comment(&self) -> bool {
-        match self.context {
-            In::Comment => true,
-            _ => false,
-        }
+        matches!(self.context, In::Comment)
     }
     fn is_in_stringish(&self) -> bool {
-        match self.context {
-            In::String { .. } => true,
-            In::LispBlockCommentPre { .. } => true,
-            In::LispBlockComment { .. } => true,
-            In::LispBlockCommentPost { .. } => true,
-            In::GuileBlockComment => true,
-            In::GuileBlockCommentPost => true,
-            In::JanetLongStringPre { .. } => true,
-            In::JanetLongString { .. } => true,
-            _ => false,
-        }
+        matches!(
+            self.context,
+            In::String { .. }
+                | In::LispBlockCommentPre { .. }
+                | In::LispBlockComment { .. }
+                | In::LispBlockCommentPost { .. }
+                | In::GuileBlockComment
+                | In::GuileBlockCommentPost
+                | In::JanetLongStringPre { .. }
+                | In::JanetLongString { .. }
+        )
     }
 }
 
@@ -308,8 +293,8 @@ fn get_initial_result<'a>(text: &'a str, options: &Options, mode: Mode, smart: b
     .any(|is_true| *is_true);
 
     State {
-        mode: mode,
-        smart: smart,
+        mode,
+        smart,
 
         orig_text: text,
         orig_cursor_x: options.cursor_x,
@@ -320,7 +305,7 @@ fn get_initial_result<'a>(text: &'a str, options: &Options, mode: Mode, smart: b
         input_x: 0,
 
         lines: vec![],
-        line_no: usize::max_value(),
+        line_no: usize::MAX,
         ch: &text[0..0],
         x: 0,
         indent_x: None,
@@ -448,12 +433,12 @@ fn column_byte_index(s: &str, x: usize) -> usize {
     s.grapheme_indices(true)
         .scan(0, |column, (idx, ch)| {
             let start_column = *column;
-            *column = *column + UnicodeWidthStr::width(ch);
+            *column += UnicodeWidthStr::width(ch);
             Some((start_column, (idx, ch)))
         })
         .filter_map(|(n, (idx, _))| if n == x { Some(idx) } else { None })
-        .nth(0)
-        .unwrap_or_else(|| s.len())
+        .next()
+        .unwrap_or(s.len())
 }
 
 #[cfg(test)]
@@ -518,7 +503,7 @@ fn get_line_ending_works() {
 
 // {{{1 Line operations
 
-fn is_cursor_affected<'a>(result: &State<'a>, start: Column, end: Column) -> bool {
+fn is_cursor_affected(result: &State<'_>, start: Column, end: Column) -> bool {
     match result.cursor_x {
         Some(x) if x == start && x == end => x == 0,
         Some(x) => x >= end,
@@ -526,8 +511,8 @@ fn is_cursor_affected<'a>(result: &State<'a>, start: Column, end: Column) -> boo
     }
 }
 
-fn shift_cursor_on_edit<'a>(
-    result: &mut State<'a>,
+fn shift_cursor_on_edit(
+    result: &mut State<'_>,
     line_no: LineNumber,
     start: Column,
     end: Column,
@@ -544,8 +529,8 @@ fn shift_cursor_on_edit<'a>(
     }
 }
 
-fn replace_within_line<'a>(
-    result: &mut State<'a>,
+fn replace_within_line(
+    result: &mut State<'_>,
     line_no: LineNumber,
     start: Column,
     end: Column,
@@ -558,11 +543,11 @@ fn replace_within_line<'a>(
     shift_cursor_on_edit(result, line_no, start, end, replace);
 }
 
-fn insert_within_line<'a>(result: &mut State<'a>, line_no: LineNumber, idx: Column, insert: &str) {
+fn insert_within_line(result: &mut State<'_>, line_no: LineNumber, idx: Column, insert: &str) {
     replace_within_line(result, line_no, idx, idx, insert);
 }
 
-fn init_line<'a>(result: &mut State<'a>) {
+fn init_line(result: &mut State<'_>) {
     result.x = 0;
     result.line_no = usize::wrapping_add(result.line_no, 1);
 
@@ -624,7 +609,7 @@ fn clamp_works() {
     assert_eq!(clamp(1, None, None), 1);
 }
 
-fn peek<T>(array: &Vec<T>, i: usize) -> Option<&T> {
+fn peek<T>(array: &[T], i: usize) -> Option<&T> {
     if i >= array.len() {
         None
     } else {
@@ -635,11 +620,11 @@ fn peek<T>(array: &Vec<T>, i: usize) -> Option<&T> {
 #[cfg(test)]
 #[test]
 fn peek_works() {
-    assert_eq!(peek(&vec!['a'], 0), Some(&'a'));
-    assert_eq!(peek(&vec!['a'], 1), None);
-    assert_eq!(peek(&vec!['a', 'b', 'c'], 0), Some(&'c'));
-    assert_eq!(peek(&vec!['a', 'b', 'c'], 1), Some(&'b'));
-    assert_eq!(peek(&vec!['a', 'b', 'c'], 5), None);
+    assert_eq!(peek(&['a'], 0), Some(&'a'));
+    assert_eq!(peek(&['a'], 1), None);
+    assert_eq!(peek(&['a', 'b', 'c'], 0), Some(&'c'));
+    assert_eq!(peek(&['a', 'b', 'c'], 1), Some(&'b'));
+    assert_eq!(peek(&['a', 'b', 'c'], 5), None);
     let empty: Vec<char> = vec![];
     assert_eq!(peek(&empty, 0), None);
     assert_eq!(peek(&empty, 1), None);
@@ -648,10 +633,7 @@ fn peek_works() {
 // {{{1 Questions about characters
 
 fn is_close_paren(paren: &str) -> bool {
-    match paren {
-        "}" | "]" | ")" => true,
-        _ => false,
-    }
+    matches!(paren, "}" | "]" | ")")
 }
 
 fn is_valid_close_paren<'a>(paren_stack: &Vec<Paren<'a>>, ch: &'a str) -> bool {
@@ -668,19 +650,19 @@ fn is_valid_close_paren<'a>(paren_stack: &Vec<Paren<'a>>, ch: &'a str) -> bool {
     false
 }
 
-fn is_whitespace<'a>(result: &State<'a>) -> bool {
+fn is_whitespace(result: &State<'_>) -> bool {
     !result.is_escaped() && (result.ch == BLANK_SPACE || result.ch == DOUBLE_SPACE)
 }
 
-fn is_closable<'a>(result: &State<'a>) -> bool {
+fn is_closable(result: &State<'_>) -> bool {
     let ch = result.ch;
     let closer = is_close_paren(ch) && !result.is_escaped();
-    return result.is_in_code() && !is_whitespace(result) && ch != "" && !closer;
+    result.is_in_code() && !is_whitespace(result) && !ch.is_empty() && !closer
 }
 
 // {{{1 Advanced operations on characters
 
-fn check_cursor_holding<'a>(result: &State<'a>) -> Result<bool> {
+fn check_cursor_holding(result: &State<'_>) -> Result<bool> {
     let opener = peek(&result.paren_stack, 0).unwrap();
     let hold_min_x = peek(&result.paren_stack, 1).map(|p| p.x + 1).unwrap_or(0);
     let hold_max_x = opener.x;
@@ -688,7 +670,7 @@ fn check_cursor_holding<'a>(result: &State<'a>) -> Result<bool> {
     let holding = result.cursor_line == Some(opener.line_no)
         && result.cursor_x.map(|x| hold_min_x <= x).unwrap_or(false)
         && result.cursor_x.map(|x| x <= hold_max_x).unwrap_or(false);
-    let should_check_prev = result.changes.is_empty() && result.prev_cursor_line != None;
+    let should_check_prev = result.changes.is_empty() && result.prev_cursor_line.is_some();
     if should_check_prev {
         let prev_holding = result.prev_cursor_line == Some(opener.line_no)
             && result
@@ -714,23 +696,21 @@ fn check_cursor_holding<'a>(result: &State<'a>) -> Result<bool> {
     Ok(holding)
 }
 
-fn track_arg_tab_stop<'a>(result: &mut State<'a>, state: TrackingArgTabStop) {
+fn track_arg_tab_stop(result: &mut State<'_>, state: TrackingArgTabStop) {
     if state == TrackingArgTabStop::Space {
         if result.is_in_code() && is_whitespace(result) {
             result.tracking_arg_tab_stop = TrackingArgTabStop::Arg;
         }
-    } else if state == TrackingArgTabStop::Arg {
-        if !is_whitespace(result) {
-            let opener = result.paren_stack.last_mut().unwrap();
-            opener.arg_x = Some(result.x);
-            result.tracking_arg_tab_stop = TrackingArgTabStop::NotSearching;
-        }
+    } else if state == TrackingArgTabStop::Arg && !is_whitespace(result) {
+        let opener = result.paren_stack.last_mut().unwrap();
+        opener.arg_x = Some(result.x);
+        result.tracking_arg_tab_stop = TrackingArgTabStop::NotSearching;
     }
 }
 
 // {{{1 Literal character events
 
-fn in_code_on_open_paren<'a>(result: &mut State<'a>) {
+fn in_code_on_open_paren(result: &mut State<'_>) {
     let opener = Paren {
         input_line_no: result.input_line_no,
         input_x: result.input_x,
@@ -758,10 +738,10 @@ fn in_code_on_open_paren<'a>(result: &mut State<'a>) {
     result.tracking_arg_tab_stop = TrackingArgTabStop::Space;
 }
 
-fn in_code_on_matched_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
+fn in_code_on_matched_close_paren(result: &mut State<'_>) -> Result<()> {
     let mut opener = (*peek(&result.paren_stack, 0).unwrap()).clone();
     if result.return_parens {
-        set_closer(&mut opener, result.line_no, result.x, result.ch);
+        set_closer(&mut opener);
     }
 
     result.paren_trail.end_x = Some(result.x + 1);
@@ -786,7 +766,7 @@ fn in_code_on_matched_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn in_code_on_unmatched_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
+fn in_code_on_unmatched_close_paren(result: &mut State<'_>) -> Result<()> {
     match result.mode {
         Mode::Paren => {
             let in_leading_paren_trail = result.paren_trail.line_no == Some(result.line_no)
@@ -821,7 +801,7 @@ fn in_code_on_unmatched_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn in_code_on_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
+fn in_code_on_close_paren(result: &mut State<'_>) -> Result<()> {
     if is_valid_close_paren(&result.paren_stack, result.ch) {
         in_code_on_matched_close_paren(result)?;
     } else {
@@ -831,28 +811,28 @@ fn in_code_on_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn in_code_on_tab<'a>(result: &mut State<'a>) {
+fn in_code_on_tab(result: &mut State<'_>) {
     result.ch = DOUBLE_SPACE;
 }
 
-fn in_code_on_comment_char<'a>(result: &mut State<'a>) {
+fn in_code_on_comment_char(result: &mut State<'_>) {
     result.context = In::Comment;
     result.comment_x = Some(result.x);
     result.tracking_arg_tab_stop = TrackingArgTabStop::NotSearching;
 }
 
-fn on_newline<'a>(result: &mut State<'a>) {
+fn on_newline(result: &mut State<'_>) {
     if result.is_in_comment() {
         result.context = In::Code;
     }
     result.ch = "";
 }
 
-fn in_code_on_quote<'a>(result: &mut State<'a>) {
+fn in_code_on_quote(result: &mut State<'_>) {
     result.context = In::String { delim: result.ch };
     cache_error_pos(result, ErrorName::UnclosedQuote);
 }
-fn in_comment_on_quote<'a>(result: &mut State<'a>) {
+fn in_comment_on_quote(result: &mut State<'_>) {
     result.quote_danger = !result.quote_danger;
     if result.quote_danger {
         cache_error_pos(result, ErrorName::QuoteDanger);
@@ -864,33 +844,33 @@ fn in_string_on_quote<'a>(result: &mut State<'a>, delim: &'a str) {
     }
 }
 
-fn in_code_on_nsign<'a>(result: &mut State<'a>) {
+fn in_code_on_nsign(result: &mut State<'_>) {
     result.context = In::LispReaderSyntax;
 }
 
-fn in_lisp_reader_syntax_on_vline<'a>(result: &mut State<'a>) {
+fn in_lisp_reader_syntax_on_vline(result: &mut State<'_>) {
     result.context = In::LispBlockComment { depth: 1 };
 }
-fn in_lisp_reader_syntax_on_bang<'a>(result: &mut State<'a>) {
+fn in_lisp_reader_syntax_on_bang(result: &mut State<'_>) {
     result.context = In::GuileBlockComment;
 }
-fn in_lisp_reader_syntax_on_semicolon<'a>(result: &mut State<'a>) {
+fn in_lisp_reader_syntax_on_semicolon(result: &mut State<'_>) {
     result.context = In::Code;
 }
 
-fn in_lisp_block_comment_pre_on_vline<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_pre_on_vline(result: &mut State<'_>, depth: usize) {
     result.context = In::LispBlockComment { depth: depth + 1 };
 }
-fn in_lisp_block_comment_pre_on_else<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_pre_on_else(result: &mut State<'_>, depth: usize) {
     result.context = In::LispBlockComment { depth };
 }
-fn in_lisp_block_comment_on_nsign<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_on_nsign(result: &mut State<'_>, depth: usize) {
     result.context = In::LispBlockCommentPre { depth };
 }
-fn in_lisp_block_comment_on_vline<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_on_vline(result: &mut State<'_>, depth: usize) {
     result.context = In::LispBlockCommentPost { depth };
 }
-fn in_lisp_block_comment_post_on_nsign<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_post_on_nsign(result: &mut State<'_>, depth: usize) {
     let depth = depth - 1;
     if depth > 0 {
         result.context = In::LispBlockComment { depth };
@@ -898,37 +878,37 @@ fn in_lisp_block_comment_post_on_nsign<'a>(result: &mut State<'a>, depth: usize)
         result.context = In::Code;
     }
 }
-fn in_lisp_block_comment_post_on_else<'a>(result: &mut State<'a>, depth: usize) {
+fn in_lisp_block_comment_post_on_else(result: &mut State<'_>, depth: usize) {
     result.context = In::LispBlockComment { depth };
 }
 
-fn in_guile_block_comment_on_bang<'a>(result: &mut State<'a>) {
+fn in_guile_block_comment_on_bang(result: &mut State<'_>) {
     result.context = In::GuileBlockCommentPost;
 }
-fn in_guile_block_comment_post_on_nsign<'a>(result: &mut State<'a>) {
+fn in_guile_block_comment_post_on_nsign(result: &mut State<'_>) {
     result.context = In::Code;
 }
-fn in_guile_block_comment_post_on_else<'a>(result: &mut State<'a>) {
+fn in_guile_block_comment_post_on_else(result: &mut State<'_>) {
     result.context = In::GuileBlockComment;
 }
 
-fn in_code_on_grave<'a>(result: &mut State<'a>) {
+fn in_code_on_grave(result: &mut State<'_>) {
     result.context = In::JanetLongStringPre { open_delim_len: 1 };
     cache_error_pos(result, ErrorName::UnclosedQuote);
 }
-fn in_janet_long_string_pre_on_grave<'a>(result: &mut State<'a>, open_delim_len: usize) {
+fn in_janet_long_string_pre_on_grave(result: &mut State<'_>, open_delim_len: usize) {
     result.context = In::JanetLongStringPre {
         open_delim_len: open_delim_len + 1,
     };
 }
-fn in_janet_long_string_pre_on_else<'a>(result: &mut State<'a>, open_delim_len: usize) {
+fn in_janet_long_string_pre_on_else(result: &mut State<'_>, open_delim_len: usize) {
     result.context = In::JanetLongString {
         open_delim_len,
         close_delim_len: 0,
     };
 }
-fn in_janet_long_string_on_grave<'a>(
-    result: &mut State<'a>,
+fn in_janet_long_string_on_grave(
+    result: &mut State<'_>,
     open_delim_len: usize,
     close_delim_len: usize,
 ) {
@@ -942,8 +922,8 @@ fn in_janet_long_string_on_grave<'a>(
         };
     }
 }
-fn in_janet_long_string_on_else<'a>(
-    result: &mut State<'a>,
+fn in_janet_long_string_on_else(
+    result: &mut State<'_>,
     open_delim_len: usize,
     close_delim_len: usize,
 ) {
@@ -955,17 +935,15 @@ fn in_janet_long_string_on_else<'a>(
     }
 }
 
-fn on_backslash<'a>(result: &mut State<'a>) {
+fn on_backslash(result: &mut State<'_>) {
     result.escape = Now::Escaping;
 }
 
-fn after_backslash<'a>(result: &mut State<'a>) -> Result<()> {
+fn after_backslash(result: &mut State<'_>) -> Result<()> {
     result.escape = Now::Escaped;
 
-    if result.ch == NEWLINE {
-        if result.is_in_code() {
-            return error(result, ErrorName::EolBackslash);
-        }
+    if result.ch == NEWLINE && result.is_in_code() {
+        return error(result, ErrorName::EolBackslash);
     }
 
     Ok(())
@@ -973,7 +951,7 @@ fn after_backslash<'a>(result: &mut State<'a>) -> Result<()> {
 
 // {{{1 Character dispatch
 
-fn on_context<'a>(result: &mut State<'a>) -> Result<()> {
+fn on_context(result: &mut State<'_>) -> Result<()> {
     let ch = result.ch;
     match result.context {
         In::Code => match ch {
@@ -1031,10 +1009,11 @@ fn on_context<'a>(result: &mut State<'a>) -> Result<()> {
             NUMBER_SIGN => in_lisp_block_comment_post_on_nsign(result, depth),
             _ => in_lisp_block_comment_post_on_else(result, depth),
         },
-        In::GuileBlockComment => match ch {
-            BANG => in_guile_block_comment_on_bang(result),
-            _ => (),
-        },
+        In::GuileBlockComment => {
+            if ch == BANG {
+                in_guile_block_comment_on_bang(result)
+            }
+        }
         In::GuileBlockCommentPost => match ch {
             NUMBER_SIGN => in_guile_block_comment_post_on_nsign(result),
             _ => in_guile_block_comment_post_on_else(result),
@@ -1055,7 +1034,7 @@ fn on_context<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
+fn on_char(result: &mut State<'_>) -> Result<()> {
     let mut ch = result.ch;
     if result.is_escaped() {
         result.escape = Now::Normal;
@@ -1089,7 +1068,7 @@ fn on_char<'a>(result: &mut State<'a>) -> Result<()> {
 
 // {{{1 Cursor functions
 
-fn is_cursor_left_of<'a>(
+fn is_cursor_left_of(
     cursor_x: Option<Column>,
     cursor_line: Option<LineNumber>,
     x: Option<Column>,
@@ -1102,7 +1081,7 @@ fn is_cursor_left_of<'a>(
     }
 }
 
-fn is_cursor_right_of<'a>(
+fn is_cursor_right_of(
     cursor_x: Option<Column>,
     cursor_line: Option<LineNumber>,
     x: Option<Column>,
@@ -1115,15 +1094,15 @@ fn is_cursor_right_of<'a>(
     }
 }
 
-fn is_cursor_in_comment<'a>(
-    result: &State<'a>,
+fn is_cursor_in_comment(
+    result: &State<'_>,
     cursor_x: Option<Column>,
     cursor_line: Option<LineNumber>,
 ) -> bool {
     is_cursor_right_of(cursor_x, cursor_line, result.comment_x, result.line_no)
 }
 
-fn handle_change_delta<'a>(result: &mut State<'a>) {
+fn handle_change_delta(result: &mut State<'_>) {
     if !result.changes.is_empty() && (result.smart || result.mode == Mode::Paren) {
         if let Some(change) = result.changes.get(&(result.input_line_no, result.input_x)) {
             result.indent_delta += change.new_end_x as Delta - change.old_end_x as Delta;
@@ -1133,7 +1112,7 @@ fn handle_change_delta<'a>(result: &mut State<'a>) {
 
 // {{{1 Paren Trail functions
 
-fn reset_paren_trail<'a>(result: &mut State<'a>, line_no: LineNumber, x: Column) {
+fn reset_paren_trail(result: &mut State<'_>, line_no: LineNumber, x: Column) {
     result.paren_trail.line_no = Some(line_no);
     result.paren_trail.start_x = Some(x);
     result.paren_trail.end_x = Some(x);
@@ -1143,8 +1122,8 @@ fn reset_paren_trail<'a>(result: &mut State<'a>, line_no: LineNumber, x: Column)
     result.paren_trail.clamped.openers = vec![];
 }
 
-fn is_cursor_clamping_paren_trail<'a>(
-    result: &State<'a>,
+fn is_cursor_clamping_paren_trail(
+    result: &State<'_>,
     cursor_x: Option<Column>,
     cursor_line: Option<LineNumber>,
 ) -> bool {
@@ -1157,7 +1136,7 @@ fn is_cursor_clamping_paren_trail<'a>(
 }
 
 // INDENT MODE: allow the cursor to clamp the paren trail
-fn clamp_paren_trail_to_cursor<'a>(result: &mut State<'a>) {
+fn clamp_paren_trail_to_cursor(result: &mut State<'_>) {
     let clamping = is_cursor_clamping_paren_trail(result, result.cursor_x, result.cursor_line);
     if clamping {
         let start_x = result.paren_trail.start_x.unwrap();
@@ -1170,7 +1149,7 @@ fn clamp_paren_trail_to_cursor<'a>(result: &mut State<'a>) {
         let mut remove_count = 0;
         for (x, ch) in line.graphemes(true).scan(0, |column, ch| {
             let start_column = *column;
-            *column = *column + UnicodeWidthStr::width(ch);
+            *column += UnicodeWidthStr::width(ch);
             Some((start_column, ch))
         }) {
             if x < start_x || x >= new_start_x {
@@ -1183,17 +1162,17 @@ fn clamp_paren_trail_to_cursor<'a>(result: &mut State<'a>) {
 
         let openers = result.paren_trail.openers.clone();
 
-        result.paren_trail.openers = (&openers[remove_count..]).to_vec();
+        result.paren_trail.openers = openers[remove_count..].to_vec();
         result.paren_trail.start_x = Some(new_start_x);
         result.paren_trail.end_x = Some(new_end_x);
 
-        result.paren_trail.clamped.openers = (&openers[..remove_count]).to_vec();
+        result.paren_trail.clamped.openers = openers[..remove_count].to_vec();
         result.paren_trail.clamped.start_x = Some(start_x);
         result.paren_trail.clamped.end_x = Some(end_x);
     }
 }
 
-fn pop_paren_trail<'a>(result: &mut State<'a>) {
+fn pop_paren_trail(result: &mut State<'_>) {
     let start_x = result.paren_trail.start_x;
     let end_x = result.paren_trail.end_x;
 
@@ -1206,7 +1185,8 @@ fn pop_paren_trail<'a>(result: &mut State<'a>) {
     }
 }
 
-fn get_parent_opener_index<'a>(result: &mut State<'a>, indent_x: usize) -> usize {
+#[allow(clippy::if_same_then_else)]
+fn get_parent_opener_index(result: &mut State<'_>, indent_x: usize) -> usize {
     for i in 0..result.paren_stack.len() {
         let opener = peek(&result.paren_stack, i).unwrap().clone();
         let opener_index = result.paren_stack.len() - i - 1;
@@ -1304,11 +1284,8 @@ fn get_parent_opener_index<'a>(result: &mut State<'a>, indent_x: usize) -> usize
                 {
                     // we can only disallow adoption if nextOpener.indentDelta will actually
                     // prevent the indentX from being in the opener's threshold.
-                    if indent_x as Delta + next_opener.unwrap().indent_delta > opener.x as Delta {
-                        is_parent = true;
-                    } else {
-                        is_parent = false;
-                    }
+                    is_parent =
+                        indent_x as Delta + next_opener.unwrap().indent_delta > opener.x as Delta;
                 }
                 // 2. ALLOW ADOPTION
                 // ```in
@@ -1393,20 +1370,15 @@ fn get_parent_opener_index<'a>(result: &mut State<'a>, indent_x: usize) -> usize
 }
 
 // INDENT MODE: correct paren trail from indentation
-fn correct_paren_trail<'a>(result: &mut State<'a>, indent_x: usize) {
+fn correct_paren_trail(result: &mut State<'_>, indent_x: usize) {
     let mut parens = String::new();
 
     let index = get_parent_opener_index(result, indent_x);
-    for i in 0..index {
+    for _ in 0..index {
         let mut opener = result.paren_stack.pop().unwrap();
         let close_ch = match_paren(opener.ch).unwrap();
         if result.return_parens {
-            opener.closer = Some(Closer {
-                line_no: result.paren_trail.line_no.unwrap(),
-                x: result.paren_trail.start_x.unwrap() + i,
-                ch: close_ch,
-                trail: None,
-            });
+            opener.closer = Some(Closer { trail: None });
         }
         result.paren_trail.openers.push(opener);
         parens.push_str(close_ch);
@@ -1421,7 +1393,7 @@ fn correct_paren_trail<'a>(result: &mut State<'a>, indent_x: usize) {
     }
 }
 
-fn clean_paren_trail<'a>(result: &mut State<'a>) {
+fn clean_paren_trail(result: &mut State<'_>) {
     let start_x = result.paren_trail.start_x;
     let end_x = result.paren_trail.end_x;
 
@@ -1438,7 +1410,7 @@ fn clean_paren_trail<'a>(result: &mut State<'a>) {
         .graphemes(true)
         .scan(0, |column, ch| {
             let start_column = *column;
-            *column = *column + UnicodeWidthStr::width(ch);
+            *column += UnicodeWidthStr::width(ch);
             Some((start_column, ch))
         })
     {
@@ -1460,25 +1432,15 @@ fn clean_paren_trail<'a>(result: &mut State<'a>) {
     }
 }
 
-fn set_closer<'a>(opener: &mut Paren<'a>, line_no: LineNumber, x: Column, ch: &'a str) {
-    opener.closer = Some(Closer {
-        line_no,
-        x,
-        ch,
-        trail: None,
-    })
+fn set_closer(opener: &mut Paren<'_>) {
+    opener.closer = Some(Closer { trail: None })
 }
 
-fn append_paren_trail<'a>(result: &mut State<'a>) {
+fn append_paren_trail(result: &mut State<'_>) {
     let mut opener = result.paren_stack.pop().unwrap().clone();
     let close_ch = match_paren(opener.ch).unwrap();
     if result.return_parens {
-        set_closer(
-            &mut opener,
-            result.paren_trail.line_no.unwrap(),
-            result.paren_trail.end_x.unwrap(),
-            close_ch,
-        );
+        set_closer(&mut opener);
     }
 
     set_max_indent(result, &opener);
@@ -1491,11 +1453,11 @@ fn append_paren_trail<'a>(result: &mut State<'a>) {
     update_remembered_paren_trail(result);
 }
 
-fn invalidate_paren_trail<'a>(result: &mut State<'a>) {
+fn invalidate_paren_trail(result: &mut State<'_>) {
     result.paren_trail = initial_paren_trail();
 }
 
-fn check_unmatched_outside_paren_trail<'a>(result: &mut State<'a>) -> Result<()> {
+fn check_unmatched_outside_paren_trail(result: &mut State<'_>) -> Result<()> {
     let mut do_error = false;
     if let Some(cache) = result.error_pos_cache.get(&ErrorName::UnmatchedCloseParen) {
         if result
@@ -1523,9 +1485,9 @@ fn set_max_indent<'a>(result: &mut State<'a>, opener: &Paren<'a>) {
     }
 }
 
-fn remember_paren_trail<'a>(result: &mut State<'a>) {
-    if result.paren_trail.clamped.openers.len() > 0 || result.paren_trail.openers.len() > 0 {
-        let is_clamped = result.paren_trail.clamped.start_x != None;
+fn remember_paren_trail(result: &mut State<'_>) {
+    if !result.paren_trail.clamped.openers.is_empty() || !result.paren_trail.openers.is_empty() {
+        let is_clamped = result.paren_trail.clamped.start_x.is_some();
         let short_trail = ParenTrail {
             line_no: result.paren_trail.line_no.unwrap(),
             start_x: if is_clamped {
@@ -1552,7 +1514,7 @@ fn remember_paren_trail<'a>(result: &mut State<'a>) {
     }
 }
 
-fn update_remembered_paren_trail<'a>(result: &mut State<'a>) {
+fn update_remembered_paren_trail(result: &mut State<'_>) {
     if result.paren_trails.is_empty()
         || Some(result.paren_trails[result.paren_trails.len() - 1].line_no)
             != result.paren_trail.line_no
@@ -1570,14 +1532,14 @@ fn update_remembered_paren_trail<'a>(result: &mut State<'a>) {
     }
 }
 
-fn finish_new_paren_trail<'a>(result: &mut State<'a>) {
+fn finish_new_paren_trail(result: &mut State<'_>) {
     if result.is_in_stringish() {
         invalidate_paren_trail(result);
     } else if result.mode == Mode::Indent {
         clamp_paren_trail_to_cursor(result);
         pop_paren_trail(result);
     } else if result.mode == Mode::Paren {
-        if let Some(paren) = peek(&result.paren_trail.openers, 0).map(Clone::clone) {
+        if let Some(paren) = peek(&result.paren_trail.openers, 0).cloned() {
             set_max_indent(result, &paren);
         }
         if Some(result.line_no) != result.cursor_line {
@@ -1589,7 +1551,7 @@ fn finish_new_paren_trail<'a>(result: &mut State<'a>) {
 
 // {{{1 Indentation functions
 
-fn add_indent<'a>(result: &mut State<'a>, delta: Delta) {
+fn add_indent(result: &mut State<'_>, delta: Delta) {
     let orig_indent = result.x;
     let new_indent = (orig_indent as Delta + delta) as Column;
     let indent_str = repeat_string(BLANK_SPACE, new_indent);
@@ -1606,7 +1568,7 @@ fn should_add_opener_indent<'a>(result: &State<'a>, opener: &Paren<'a>) -> bool 
     opener.indent_delta != result.indent_delta
 }
 
-fn correct_indent<'a>(result: &mut State<'a>) {
+fn correct_indent(result: &mut State<'_>) {
     let orig_indent = result.x as Delta;
     let mut new_indent = orig_indent as Delta;
     let mut min_indent = 0;
@@ -1627,7 +1589,7 @@ fn correct_indent<'a>(result: &mut State<'a>) {
     }
 }
 
-fn on_indent<'a>(result: &mut State<'a>) -> Result<()> {
+fn on_indent(result: &mut State<'_>) -> Result<()> {
     result.indent_x = Some(result.x);
     result.tracking_indent = false;
 
@@ -1657,7 +1619,7 @@ fn on_indent<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn check_leading_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
+fn check_leading_close_paren(result: &mut State<'_>) -> Result<()> {
     if result
         .error_pos_cache
         .contains_key(&ErrorName::LeadingCloseParen)
@@ -1669,7 +1631,7 @@ fn check_leading_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn on_leading_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
+fn on_leading_close_paren(result: &mut State<'_>) -> Result<()> {
     match result.mode {
         Mode::Indent => {
             if !result.force_balance {
@@ -1712,7 +1674,7 @@ fn on_leading_close_paren<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn on_comment_line<'a>(result: &mut State<'a>) {
+fn on_comment_line(result: &mut State<'_>) {
     let paren_trail_length = result.paren_trail.openers.len();
 
     // restore the openers matching the previous paren trail
@@ -1746,7 +1708,7 @@ fn on_comment_line<'a>(result: &mut State<'a>) {
     }
 }
 
-fn check_indent<'a>(result: &mut State<'a>) -> Result<()> {
+fn check_indent(result: &mut State<'_>) -> Result<()> {
     if is_close_paren(result.ch) {
         on_leading_close_paren(result)?;
     } else if result.ch == result.comment_char {
@@ -1769,11 +1731,11 @@ fn make_tab_stop<'a>(opener: &Paren<'a>) -> TabStop<'a> {
     }
 }
 
-fn get_tab_stop_line<'a>(result: &State<'a>) -> Option<LineNumber> {
+fn get_tab_stop_line(result: &State<'_>) -> Option<LineNumber> {
     result.selection_start_line.or(result.cursor_line)
 }
 
-fn set_tab_stops<'a>(result: &mut State<'a>) {
+fn set_tab_stops(result: &mut State<'_>) {
     if get_tab_stop_line(result) != Some(result.line_no) {
         return;
     }
@@ -1827,7 +1789,7 @@ fn process_char<'a>(result: &mut State<'a>, ch: &'a str) -> Result<()> {
     Ok(())
 }
 
-fn process_line<'a>(result: &mut State<'a>, line_no: usize) -> Result<()> {
+fn process_line(result: &mut State<'_>, line_no: usize) -> Result<()> {
     init_line(result);
     result.lines.push(Cow::from(result.input_lines[line_no]));
 
@@ -1837,7 +1799,7 @@ fn process_line<'a>(result: &mut State<'a>, line_no: usize) -> Result<()> {
         .graphemes(true)
         .scan(0, |column, ch| {
             let start_column = *column;
-            *column = *column + UnicodeWidthStr::width(ch);
+            *column += UnicodeWidthStr::width(ch);
             Some((start_column, ch))
         })
     {
@@ -1858,7 +1820,7 @@ fn process_line<'a>(result: &mut State<'a>, line_no: usize) -> Result<()> {
     Ok(())
 }
 
-fn finalize_result<'a>(result: &mut State<'a>) -> Result<()> {
+fn finalize_result(result: &mut State<'_>) -> Result<()> {
     if result.quote_danger {
         error(result, ErrorName::QuoteDanger)?;
     }
@@ -1866,10 +1828,8 @@ fn finalize_result<'a>(result: &mut State<'a>) -> Result<()> {
         error(result, ErrorName::UnclosedQuote)?;
     }
 
-    if result.paren_stack.len() != 0 {
-        if result.mode == Mode::Paren {
-            error(result, ErrorName::UnclosedParen)?;
-        }
+    if !result.paren_stack.is_empty() && result.mode == Mode::Paren {
+        error(result, ErrorName::UnclosedParen)?;
     }
     if result.mode == Mode::Indent {
         init_line(result);
@@ -1880,24 +1840,24 @@ fn finalize_result<'a>(result: &mut State<'a>) -> Result<()> {
     Ok(())
 }
 
-fn process_error<'a>(result: &mut State<'a>, e: Error) {
+fn process_error(result: &mut State<'_>, e: Error) {
     result.success = false;
     result.error = Some(e);
 }
 
 fn process_text<'a>(text: &'a str, options: &Options, mode: Mode, smart: bool) -> State<'a> {
-    let mut result = get_initial_result(text, &options, mode, smart);
+    let mut result = get_initial_result(text, options, mode, smart);
 
     let mut process_result: Result<()> = Ok(());
     for i in 0..result.input_lines.len() {
         result.input_line_no = i;
         process_result = process_line(&mut result, i);
-        if let Err(_) = process_result {
+        if process_result.is_err() {
             break;
         }
     }
 
-    if let Ok(_) = process_result {
+    if process_result.is_ok() {
         process_result = finalize_result(&mut result);
     }
 
@@ -1905,7 +1865,7 @@ fn process_text<'a>(text: &'a str, options: &Options, mode: Mode, smart: bool) -
         Err(Error {
             name: ErrorName::Restart,
             ..
-        }) => process_text(text, &options, Mode::Paren, smart),
+        }) => process_text(text, options, Mode::Paren, smart),
         Err(e) => {
             process_error(&mut result, e);
             result
@@ -1916,7 +1876,7 @@ fn process_text<'a>(text: &'a str, options: &Options, mode: Mode, smart: bool) -
 
 // {{{1 Public API
 
-fn public_result<'a>(result: State<'a>) -> Answer<'a> {
+fn public_result(result: State<'_>) -> Answer<'_> {
     let line_ending = get_line_ending(result.orig_text);
     if result.success {
         Answer {
@@ -1964,7 +1924,7 @@ pub fn paren_mode<'a>(text: &'a str, options: &Options) -> Answer<'a> {
 }
 
 pub fn smart_mode<'a>(text: &'a str, options: &Options) -> Answer<'a> {
-    let smart = options.selection_start_line == None;
+    let smart = options.selection_start_line.is_none();
     public_result(process_text(text, options, Mode::Indent, smart))
 }
 
@@ -1976,11 +1936,11 @@ pub fn process(request: &Request) -> Answer {
     }
 
     if request.mode == "paren" {
-        Answer::from(paren_mode(&request.text, &options))
+        paren_mode(&request.text, &options)
     } else if request.mode == "indent" {
-        Answer::from(indent_mode(&request.text, &options))
+        indent_mode(&request.text, &options)
     } else if request.mode == "smart" {
-        Answer::from(smart_mode(&request.text, &options))
+        smart_mode(&request.text, &options)
     } else {
         Answer::from(Error {
             message: String::from("Bad value specified for `mode`"),
@@ -1991,7 +1951,7 @@ pub fn process(request: &Request) -> Answer {
 
 // This is like the process function above, but uses a reference counted version of Request
 #[allow(dead_code)]
-pub fn rc_process<'a>(request: &'a SharedRequest) -> Answer<'a> {
+pub fn rc_process(request: &SharedRequest) -> Answer<'_> {
     let mut options = request.options.clone();
 
     if let Some(ref prev_text) = request.options.prev_text {
@@ -1999,11 +1959,11 @@ pub fn rc_process<'a>(request: &'a SharedRequest) -> Answer<'a> {
     }
 
     if request.mode == "paren" {
-        Answer::from(paren_mode(&request.text, &options))
+        paren_mode(&request.text, &options)
     } else if request.mode == "indent" {
-        Answer::from(indent_mode(&request.text, &options))
+        indent_mode(&request.text, &options)
     } else if request.mode == "smart" {
-        Answer::from(smart_mode(&request.text, &options))
+        smart_mode(&request.text, &options)
     } else {
         Answer::from(Error {
             message: String::from("Bad value specified for `mode`"),

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use crate::changes;
+use crate::types::*;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
-use crate::types::*;
-use crate::changes;
 
 // {{{1 Constants / Predicates
 
@@ -147,10 +147,16 @@ enum Now {
 
 impl<'a> State<'a> {
     fn is_escaping(&self) -> bool {
-        match self.escape { Now::Escaping => true, _ => false }
+        match self.escape {
+            Now::Escaping => true,
+            _ => false,
+        }
     }
     fn is_escaped(&self) -> bool {
-        match self.escape { Now::Escaped => true, _ => false }
+        match self.escape {
+            Now::Escaped => true,
+            _ => false,
+        }
     }
 }
 
@@ -158,15 +164,28 @@ impl<'a> State<'a> {
 enum In<'a> {
     Code,
     Comment,
-    String { delim: &'a str },
+    String {
+        delim: &'a str,
+    },
     LispReaderSyntax,
-    LispBlockCommentPre { depth: usize },
-    LispBlockComment { depth: usize },
-    LispBlockCommentPost { depth: usize },
+    LispBlockCommentPre {
+        depth: usize,
+    },
+    LispBlockComment {
+        depth: usize,
+    },
+    LispBlockCommentPost {
+        depth: usize,
+    },
     GuileBlockComment,
     GuileBlockCommentPost,
-    JanetLongStringPre { open_delim_len: usize },
-    JanetLongString { open_delim_len: usize, close_delim_len: usize },
+    JanetLongStringPre {
+        open_delim_len: usize,
+    },
+    JanetLongString {
+        open_delim_len: usize,
+        close_delim_len: usize,
+    },
 }
 
 impl<'a> State<'a> {
@@ -174,23 +193,26 @@ impl<'a> State<'a> {
         match self.context {
             In::Code => true,
             In::LispReaderSyntax => true,
-            _ => false
+            _ => false,
         }
     }
     fn is_in_comment(&self) -> bool {
-        match self.context { In::Comment => true, _ => false }
+        match self.context {
+            In::Comment => true,
+            _ => false,
+        }
     }
     fn is_in_stringish(&self) -> bool {
         match self.context {
-            In::String {..} => true,
-            In::LispBlockCommentPre {..} => true,
-            In::LispBlockComment {..} => true,
-            In::LispBlockCommentPost {..} => true,
+            In::String { .. } => true,
+            In::LispBlockCommentPre { .. } => true,
+            In::LispBlockComment { .. } => true,
+            In::LispBlockCommentPost { .. } => true,
             In::GuileBlockComment => true,
             In::GuileBlockCommentPost => true,
-            In::JanetLongStringPre {..} => true,
-            In::JanetLongString {..} => true,
-            _ => false
+            In::JanetLongStringPre { .. } => true,
+            In::JanetLongString { .. } => true,
+            _ => false,
         }
     }
 }
@@ -276,17 +298,14 @@ fn initial_paren_trail<'a>() -> InternalParenTrail<'a> {
     }
 }
 
-fn get_initial_result<'a>(
-    text: &'a str,
-    options: &Options,
-    mode: Mode,
-    smart: bool,
-) -> State<'a> {
+fn get_initial_result<'a>(text: &'a str, options: &Options, mode: Mode, smart: bool) -> State<'a> {
     let lisp_reader_syntax_enabled = [
         options.lisp_block_comments,
         options.guile_block_comments,
         options.scheme_sexp_comments,
-    ].iter().any(|is_true| *is_true);
+    ]
+    .iter()
+    .any(|is_true| *is_true);
 
     State {
         mode: mode,
@@ -433,7 +452,7 @@ fn column_byte_index(s: &str, x: usize) -> usize {
             Some((start_column, (idx, ch)))
         })
         .filter_map(|(n, (idx, _))| if n == x { Some(idx) } else { None })
-        .nth(0) 
+        .nth(0)
         .unwrap_or_else(|| s.len())
 }
 
@@ -659,7 +678,6 @@ fn is_closable<'a>(result: &State<'a>) -> bool {
     return result.is_in_code() && !is_whitespace(result) && ch != "" && !closer;
 }
 
-
 // {{{1 Advanced operations on characters
 
 fn check_cursor_holding<'a>(result: &State<'a>) -> Result<bool> {
@@ -726,7 +744,7 @@ fn in_code_on_open_paren<'a>(result: &mut State<'a>) {
         arg_x: None,
 
         closer: None,
-        children: vec![]
+        children: vec![],
     };
 
     if result.return_parens {
@@ -899,22 +917,41 @@ fn in_code_on_grave<'a>(result: &mut State<'a>) {
     cache_error_pos(result, ErrorName::UnclosedQuote);
 }
 fn in_janet_long_string_pre_on_grave<'a>(result: &mut State<'a>, open_delim_len: usize) {
-    result.context = In::JanetLongStringPre { open_delim_len: open_delim_len + 1 };
+    result.context = In::JanetLongStringPre {
+        open_delim_len: open_delim_len + 1,
+    };
 }
 fn in_janet_long_string_pre_on_else<'a>(result: &mut State<'a>, open_delim_len: usize) {
-    result.context = In::JanetLongString { open_delim_len, close_delim_len: 0 };
+    result.context = In::JanetLongString {
+        open_delim_len,
+        close_delim_len: 0,
+    };
 }
-fn in_janet_long_string_on_grave<'a>(result: &mut State<'a>, open_delim_len: usize, close_delim_len: usize) {
+fn in_janet_long_string_on_grave<'a>(
+    result: &mut State<'a>,
+    open_delim_len: usize,
+    close_delim_len: usize,
+) {
     let close_delim_len = close_delim_len + 1;
     if open_delim_len == close_delim_len {
         result.context = In::Code;
     } else {
-        result.context = In::JanetLongString { open_delim_len, close_delim_len };
+        result.context = In::JanetLongString {
+            open_delim_len,
+            close_delim_len,
+        };
     }
 }
-fn in_janet_long_string_on_else<'a>(result: &mut State<'a>, open_delim_len: usize, close_delim_len: usize) {
+fn in_janet_long_string_on_else<'a>(
+    result: &mut State<'a>,
+    open_delim_len: usize,
+    close_delim_len: usize,
+) {
     if close_delim_len > 0 {
-        result.context = In::JanetLongString { open_delim_len, close_delim_len: 0 };
+        result.context = In::JanetLongString {
+            open_delim_len,
+            close_delim_len: 0,
+        };
     }
 }
 
@@ -939,88 +976,79 @@ fn after_backslash<'a>(result: &mut State<'a>) -> Result<()> {
 fn on_context<'a>(result: &mut State<'a>) -> Result<()> {
     let ch = result.ch;
     match result.context {
-        In::Code => {
-            match ch {
-                _ if ch == result.comment_char => in_code_on_comment_char(result),
-                _ if result.string_delimiters.contains(&ch.to_string()) => in_code_on_quote(result),
-                "(" | "[" | "{" => in_code_on_open_paren(result),
-                ")" | "]" | "}" => in_code_on_close_paren(result)?,
-                VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_code_on_quote(result),
-                NUMBER_SIGN if result.lisp_reader_syntax_enabled => in_code_on_nsign(result),
-                GRAVE if result.janet_long_strings_enabled => in_code_on_grave(result),
-                TAB => in_code_on_tab(result),
-                _ => (),
-            }
+        In::Code => match ch {
+            _ if ch == result.comment_char => in_code_on_comment_char(result),
+            _ if result.string_delimiters.contains(&ch.to_string()) => in_code_on_quote(result),
+            "(" | "[" | "{" => in_code_on_open_paren(result),
+            ")" | "]" | "}" => in_code_on_close_paren(result)?,
+            VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_code_on_quote(result),
+            NUMBER_SIGN if result.lisp_reader_syntax_enabled => in_code_on_nsign(result),
+            GRAVE if result.janet_long_strings_enabled => in_code_on_grave(result),
+            TAB => in_code_on_tab(result),
+            _ => (),
         },
-        In::Comment => {
-            match ch {
-                _ if result.string_delimiters.contains(&ch.to_string()) => in_comment_on_quote(result),
-                VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_comment_on_quote(result),
-                GRAVE if result.janet_long_strings_enabled => in_comment_on_quote(result),
-                _ => (),
-            }
+        In::Comment => match ch {
+            _ if result.string_delimiters.contains(&ch.to_string()) => in_comment_on_quote(result),
+            VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_comment_on_quote(result),
+            GRAVE if result.janet_long_strings_enabled => in_comment_on_quote(result),
+            _ => (),
         },
-        In::String { delim } => {
-            match ch {
-                _ if result.string_delimiters.contains(&ch.to_string()) => in_string_on_quote(result, delim),
-                VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_string_on_quote(result, delim),
-                _ => (),
+        In::String { delim } => match ch {
+            _ if result.string_delimiters.contains(&ch.to_string()) => {
+                in_string_on_quote(result, delim)
             }
+            VERTICAL_LINE if result.lisp_vline_symbols_enabled => in_string_on_quote(result, delim),
+            _ => (),
         },
         In::LispReaderSyntax => {
             match ch {
-                VERTICAL_LINE if result.lisp_block_comments_enabled => in_lisp_reader_syntax_on_vline(result),
-                BANG if result.guile_block_comments_enabled => in_lisp_reader_syntax_on_bang(result),
-                ";" if result.scheme_sexp_comments_enabled => in_lisp_reader_syntax_on_semicolon(result),
+                VERTICAL_LINE if result.lisp_block_comments_enabled => {
+                    in_lisp_reader_syntax_on_vline(result)
+                }
+                BANG if result.guile_block_comments_enabled => {
+                    in_lisp_reader_syntax_on_bang(result)
+                }
+                ";" if result.scheme_sexp_comments_enabled => {
+                    in_lisp_reader_syntax_on_semicolon(result)
+                }
                 _ => {
                     // Backtrack!
                     result.context = In::Code;
                     on_context(result)?
-                },
+                }
             }
+        }
+        In::LispBlockCommentPre { depth } => match ch {
+            VERTICAL_LINE => in_lisp_block_comment_pre_on_vline(result, depth),
+            _ => in_lisp_block_comment_pre_on_else(result, depth),
         },
-        In::LispBlockCommentPre { depth } => {
-            match ch {
-                VERTICAL_LINE => in_lisp_block_comment_pre_on_vline(result, depth),
-                _ => in_lisp_block_comment_pre_on_else(result, depth),
-            }
+        In::LispBlockComment { depth } => match ch {
+            NUMBER_SIGN => in_lisp_block_comment_on_nsign(result, depth),
+            VERTICAL_LINE => in_lisp_block_comment_on_vline(result, depth),
+            _ => (),
         },
-        In::LispBlockComment { depth } => {
-            match ch {
-                NUMBER_SIGN => in_lisp_block_comment_on_nsign(result, depth),
-                VERTICAL_LINE => in_lisp_block_comment_on_vline(result, depth),
-                _ => (),
-            }
+        In::LispBlockCommentPost { depth } => match ch {
+            NUMBER_SIGN => in_lisp_block_comment_post_on_nsign(result, depth),
+            _ => in_lisp_block_comment_post_on_else(result, depth),
         },
-        In::LispBlockCommentPost { depth } => {
-            match ch {
-                NUMBER_SIGN => in_lisp_block_comment_post_on_nsign(result, depth),
-                _ => in_lisp_block_comment_post_on_else(result, depth),
-            }
+        In::GuileBlockComment => match ch {
+            BANG => in_guile_block_comment_on_bang(result),
+            _ => (),
         },
-        In::GuileBlockComment => {
-            match ch {
-                BANG => in_guile_block_comment_on_bang(result),
-                _ => (),
-            }
+        In::GuileBlockCommentPost => match ch {
+            NUMBER_SIGN => in_guile_block_comment_post_on_nsign(result),
+            _ => in_guile_block_comment_post_on_else(result),
         },
-        In::GuileBlockCommentPost => {
-            match ch {
-                NUMBER_SIGN => in_guile_block_comment_post_on_nsign(result),
-                _ => in_guile_block_comment_post_on_else(result),
-            }
+        In::JanetLongStringPre { open_delim_len } => match ch {
+            GRAVE => in_janet_long_string_pre_on_grave(result, open_delim_len),
+            _ => in_janet_long_string_pre_on_else(result, open_delim_len),
         },
-        In::JanetLongStringPre { open_delim_len } => {
-            match ch {
-                GRAVE => in_janet_long_string_pre_on_grave(result, open_delim_len),
-                _ => in_janet_long_string_pre_on_else(result, open_delim_len),
-            }
-        },
-        In::JanetLongString { open_delim_len, close_delim_len } => {
-            match ch {
-                GRAVE => in_janet_long_string_on_grave(result, open_delim_len, close_delim_len),
-                _ => in_janet_long_string_on_else(result, open_delim_len, close_delim_len),
-            }
+        In::JanetLongString {
+            open_delim_len,
+            close_delim_len,
+        } => match ch {
+            GRAVE => in_janet_long_string_on_grave(result, open_delim_len, close_delim_len),
+            _ => in_janet_long_string_on_else(result, open_delim_len, close_delim_len),
         },
     }
 
@@ -1140,14 +1168,11 @@ fn clamp_paren_trail_to_cursor<'a>(result: &mut State<'a>) {
 
         let line = &result.lines[result.line_no];
         let mut remove_count = 0;
-        for (x, ch) in line
-            .graphemes(true)
-            .scan(0, |column, ch| {
-                let start_column = *column;
-                *column = *column + UnicodeWidthStr::width(ch);
-                Some((start_column, ch))
-            })
-        {
+        for (x, ch) in line.graphemes(true).scan(0, |column, ch| {
+            let start_column = *column;
+            *column = *column + UnicodeWidthStr::width(ch);
+            Some((start_column, ch))
+        }) {
             if x < start_x || x >= new_start_x {
                 continue;
             }
@@ -1380,12 +1405,11 @@ fn correct_paren_trail<'a>(result: &mut State<'a>, indent_x: usize) {
                 line_no: result.paren_trail.line_no.unwrap(),
                 x: result.paren_trail.start_x.unwrap() + i,
                 ch: close_ch,
-                trail: None
+                trail: None,
             });
         }
         result.paren_trail.openers.push(opener);
         parens.push_str(close_ch);
-
     }
 
     if let Some(line_no) = result.paren_trail.line_no {
@@ -1411,12 +1435,12 @@ fn clean_paren_trail<'a>(result: &mut State<'a>) {
     let mut new_trail = String::new();
     let mut space_count = 0;
     for (x, ch) in result.lines[result.line_no]
-                    .graphemes(true)
-                    .scan(0, |column, ch| {
-                        let start_column = *column;
-                        *column = *column + UnicodeWidthStr::width(ch);
-                        Some((start_column, ch))
-                    })
+        .graphemes(true)
+        .scan(0, |column, ch| {
+            let start_column = *column;
+            *column = *column + UnicodeWidthStr::width(ch);
+            Some((start_column, ch))
+        })
     {
         if x < start_x || x >= end_x {
             continue;
@@ -1437,14 +1461,24 @@ fn clean_paren_trail<'a>(result: &mut State<'a>) {
 }
 
 fn set_closer<'a>(opener: &mut Paren<'a>, line_no: LineNumber, x: Column, ch: &'a str) {
-    opener.closer = Some(Closer { line_no, x, ch, trail: None })
+    opener.closer = Some(Closer {
+        line_no,
+        x,
+        ch,
+        trail: None,
+    })
 }
 
 fn append_paren_trail<'a>(result: &mut State<'a>) {
     let mut opener = result.paren_stack.pop().unwrap().clone();
     let close_ch = match_paren(opener.ch).unwrap();
     if result.return_parens {
-        set_closer(&mut opener, result.paren_trail.line_no.unwrap(), result.paren_trail.end_x.unwrap(), close_ch);
+        set_closer(
+            &mut opener,
+            result.paren_trail.line_no.unwrap(),
+            result.paren_trail.end_x.unwrap(),
+            close_ch,
+        );
     }
 
     set_max_indent(result, &opener);
@@ -1498,12 +1532,14 @@ fn remember_paren_trail<'a>(result: &mut State<'a>) {
                 result.paren_trail.clamped.start_x
             } else {
                 result.paren_trail.start_x
-            }.unwrap(),
+            }
+            .unwrap(),
             end_x: if is_clamped {
                 result.paren_trail.clamped.end_x
             } else {
                 result.paren_trail.end_x
-            }.unwrap(),
+            }
+            .unwrap(),
         };
 
         result.paren_trails.push(short_trail.clone());
@@ -1956,22 +1992,22 @@ pub fn process(request: &Request) -> Answer {
 // This is like the process function above, but uses a reference counted version of Request
 #[allow(dead_code)]
 pub fn rc_process<'a>(request: &'a SharedRequest) -> Answer<'a> {
-  let mut options = request.options.clone();
+    let mut options = request.options.clone();
 
-  if let Some(ref prev_text) = request.options.prev_text {
-    options.changes = changes::compute_text_changes(prev_text, &request.text);
-  }
+    if let Some(ref prev_text) = request.options.prev_text {
+        options.changes = changes::compute_text_changes(prev_text, &request.text);
+    }
 
-  if request.mode == "paren" {
-    Answer::from(paren_mode(&request.text, &options))
-  } else if request.mode == "indent" {
-    Answer::from(indent_mode(&request.text, &options))
-  } else if request.mode == "smart" {
-    Answer::from(smart_mode(&request.text, &options))
-  } else {
-    Answer::from(Error {
-      message: String::from("Bad value specified for `mode`"),
-      ..Error::default()
-    })
-  }
+    if request.mode == "paren" {
+        Answer::from(paren_mode(&request.text, &options))
+    } else if request.mode == "indent" {
+        Answer::from(indent_mode(&request.text, &options))
+    } else if request.mode == "smart" {
+        Answer::from(smart_mode(&request.text, &options))
+    } else {
+        Answer::from(Error {
+            message: String::from("Bad value specified for `mode`"),
+            ..Error::default()
+        })
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,7 @@
 use serde;
 use serde_json;
 use std;
-use std::{fmt,
-          mem,
-          rc::Rc};
+use std::{fmt, mem, rc::Rc};
 
 pub type LineNumber = usize;
 pub type Column = usize;
@@ -76,7 +74,7 @@ pub struct Request {
     pub options: Options,
 }
 
-#[derive(Clone,Serialize,Debug)]
+#[derive(Clone, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TabStop<'a> {
     pub ch: &'a str,
@@ -85,7 +83,7 @@ pub struct TabStop<'a> {
     pub arg_x: Option<Column>,
 }
 
-#[derive(Clone,Debug,Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ParenTrail {
     pub line_no: LineNumber,
@@ -98,10 +96,10 @@ pub struct Closer<'a> {
     pub line_no: LineNumber,
     pub x: Column,
     pub ch: &'a str,
-    pub trail: Option<ParenTrail>
+    pub trail: Option<ParenTrail>,
 }
 
-#[derive(Clone,Debug,Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Paren<'a> {
     pub line_no: LineNumber,
@@ -116,7 +114,7 @@ pub struct Paren<'a> {
     #[serde(skip)]
     pub closer: Option<Closer<'a>>,
     #[serde(skip)]
-    pub children: Vec<Paren<'a>>
+    pub children: Vec<Paren<'a>>,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -190,7 +188,8 @@ impl ToString for ErrorName {
 
 impl serde::Serialize for ErrorName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer
+    where
+        S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }
@@ -198,32 +197,34 @@ impl serde::Serialize for ErrorName {
 
 impl<'a> serde::Deserialize<'a> for ErrorName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'a>
+    where
+        D: serde::Deserializer<'a>,
     {
         struct Visitor;
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = ErrorName;
 
-            fn expecting(&self,  formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("error name")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<ErrorName, E>
-            where E: serde::de::Error
+            where
+                E: serde::de::Error,
             {
                 match value {
                     "quote-danger" => Ok(ErrorName::QuoteDanger),
-                     "eol-backslash" => Ok(ErrorName::EolBackslash),
-                     "unclosed-quote" => Ok(ErrorName::UnclosedQuote),
-                     "unclosed-paren" => Ok(ErrorName::UnclosedParen),
-                     "unmatched-close-paren" => Ok(ErrorName::UnmatchedCloseParen),
-                     "unmatched-open-paren" => Ok(ErrorName::UnmatchedOpenParen),
-                     "leading-close-paren" => Ok(ErrorName::LeadingCloseParen),
-                     "utf8-error" => Ok(ErrorName::Utf8EncodingError),
-                     "json-error" => Ok(ErrorName::JsonEncodingError),
-                     "panic" => Ok(ErrorName::Panic),
-                    _ => Err(E::custom(format!("unknown error name: {}", value)))
+                    "eol-backslash" => Ok(ErrorName::EolBackslash),
+                    "unclosed-quote" => Ok(ErrorName::UnclosedQuote),
+                    "unclosed-paren" => Ok(ErrorName::UnclosedParen),
+                    "unmatched-close-paren" => Ok(ErrorName::UnmatchedCloseParen),
+                    "unmatched-open-paren" => Ok(ErrorName::UnmatchedOpenParen),
+                    "leading-close-paren" => Ok(ErrorName::LeadingCloseParen),
+                    "utf8-error" => Ok(ErrorName::Utf8EncodingError),
+                    "json-error" => Ok(ErrorName::JsonEncodingError),
+                    "panic" => Ok(ErrorName::Panic),
+                    _ => Err(E::custom(format!("unknown error name: {}", value))),
                 }
             }
         }
@@ -282,11 +283,10 @@ const ANSWER_LEN: usize = mem::size_of::<Answer>() / 8;
 pub type RawAnswer = [u64; ANSWER_LEN];
 
 #[allow(dead_code)]
-pub struct WrappedAnswer{
-  request: SharedRequest,
-  raw: RawAnswer
+pub struct WrappedAnswer {
+    request: SharedRequest,
+    raw: RawAnswer,
 }
-
 
 impl WrappedAnswer {
     #[inline]

--- a/src/wasm_wrapper.rs
+++ b/src/wasm_wrapper.rs
@@ -1,13 +1,13 @@
-use types::*;
+use super::common_wrapper;
 use serde_json;
 use std::panic;
-use super::common_wrapper;
+use types::*;
 
 pub fn run_parinfer(input: String) -> String {
     match panic::catch_unwind(|| common_wrapper::internal_run(&input)) {
         Ok(Ok(result)) => result,
         Ok(Err(e)) => serde_json::to_string(&Answer::from(e)).unwrap(),
-        Err(_) => common_wrapper::panic_result()
+        Err(_) => common_wrapper::panic_result(),
     }
 }
 
@@ -19,15 +19,17 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let out = run_parinfer(String::from(r#"{
+        let out = run_parinfer(String::from(
+            r#"{
             "mode": "indent",
             "text": "(def x",
             "options": {
                 "cursorX": 3,
                 "cursorLine": 0
             }
-        }"#));
-        let answer : Value = serde_json::from_str(&out).unwrap();
+        }"#,
+        ));
+        let answer: Value = serde_json::from_str(&out).unwrap();
         assert_eq!(
             Value::Bool(true),
             answer["success"],

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -27,7 +27,8 @@ struct Case {
 impl Case {
     fn check2(&self, answer: serde_json::Value) {
         assert_eq!(
-            json!(self.result.success), answer["success"],
+            json!(self.result.success),
+            answer["success"],
             "case {}: success",
             self.source.line_no
         );
@@ -56,12 +57,14 @@ impl Case {
 
         if let Some(ref expected) = self.result.error {
             assert_eq!(
-                json!(expected.x), answer["error"]["x"],
+                json!(expected.x),
+                answer["error"]["x"],
                 "case {}: error.x",
                 self.source.line_no
             );
             assert_eq!(
-                json!(expected.line_no), answer["error"]["lineNo"],
+                json!(expected.line_no),
+                answer["error"]["lineNo"],
                 "case {}: error.line_no",
                 self.source.line_no
             );
@@ -80,24 +83,31 @@ impl Case {
                 "case {}: tab stop count",
                 self.source.line_no
             );
-            for (expected, actual) in tab_stops.iter().zip(answer["tabStops"].as_array().unwrap().iter()) {
+            for (expected, actual) in tab_stops
+                .iter()
+                .zip(answer["tabStops"].as_array().unwrap().iter())
+            {
                 assert_eq!(
-                    json!(expected.ch), actual["ch"],
+                    json!(expected.ch),
+                    actual["ch"],
                     "case {}: tab stop ch",
                     self.source.line_no
                 );
                 assert_eq!(
-                    json!(expected.x), actual["x"],
+                    json!(expected.x),
+                    actual["x"],
                     "case {}: tab stop x",
                     self.source.line_no
                 );
                 assert_eq!(
-                    json!(expected.line_no), actual["lineNo"],
+                    json!(expected.line_no),
+                    actual["lineNo"],
                     "case {}: tab stop line",
                     self.source.line_no
                 );
                 assert_eq!(
-                    json!(expected.arg_x), actual["argX"],
+                    json!(expected.arg_x),
+                    actual["argX"],
                     "case {}: tab stop arg_x",
                     self.source.line_no
                 );
@@ -111,7 +121,10 @@ impl Case {
                 "case {}: wrong number of paren trails",
                 self.source.line_no
             );
-            for (expected, actual) in trails.iter().zip(answer["parenTrails"].as_array().unwrap().iter()) {
+            for (expected, actual) in trails
+                .iter()
+                .zip(answer["parenTrails"].as_array().unwrap().iter())
+            {
                 assert_eq!(
                     expected.line_no, actual["lineNo"],
                     "case {}: paren trail line number",
@@ -154,7 +167,6 @@ struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     janet_long_strings: Option<bool>,
 }
-
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -213,7 +225,11 @@ fn run(input: &str) -> String {
     unsafe {
         parinfer_rust::INITIALIZED = true;
         let c_input = CString::new(input).unwrap();
-        String::from(CStr::from_ptr(parinfer_rust::run_parinfer(c_input.as_ptr())).to_str().unwrap())
+        String::from(
+            CStr::from_ptr(parinfer_rust::run_parinfer(c_input.as_ptr()))
+                .to_str()
+                .unwrap(),
+        )
     }
 }
 
@@ -230,7 +246,8 @@ pub fn indent_mode() {
             "mode": "indent",
             "text": &case.text,
             "options": &case.options
-        }).to_string();
+        })
+        .to_string();
         let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
         case.check2(answer);
     }
@@ -244,7 +261,8 @@ pub fn paren_mode() {
             "mode": "paren",
             "text": &case.text,
             "options": &case.options
-        }).to_string();
+        })
+        .to_string();
         let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
         case.check2(answer);
     }
@@ -258,7 +276,8 @@ pub fn smart_mode() {
             "mode": "smart",
             "text": &case.text,
             "options": &case.options
-        }).to_string();
+        })
+        .to_string();
         let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
         case.check2(answer);
     }
@@ -275,11 +294,9 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -290,14 +307,15 @@ pub fn composed_unicode_graphemes_count_as_a_single_character() {
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "paren",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -313,36 +331,33 @@ pub fn graphemes_in_changes_are_counted_correctly() {
             cursor_x: Some(10),
             cursor_line: Some(1),
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: Some(7),
             cursor_line: Some(1),
-            changes: Some(vec![
-                Change {
-                    line_no: 0,
-                    x: 2,
-                    old_text: String::from("éé"),
-                    new_text: String::from("xyååå"),
-                }
-            ]),
+            changes: Some(vec![Change {
+                line_no: 0,
+                x: 2,
+                old_text: String::from("éé"),
+                new_text: String::from("xyååå"),
+            }]),
             lisp_vline_symbols: None,
             lisp_block_comments: None,
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "smart",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -358,36 +373,33 @@ pub fn wide_characters() {
             cursor_x: Some(17),
             cursor_line: Some(1),
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: Some(12),
             cursor_line: Some(1),
-            changes: Some(vec![
-                Change {
-                    line_no: 0,
-                    x: 5,
-                    old_text: String::from("world"),
-                    new_text: String::from("ｗｏｒｌｄ"),
-                }
-            ]),
+            changes: Some(vec![Change {
+                line_no: 0,
+                x: 5,
+                old_text: String::from("world"),
+                new_text: String::from("ｗｏｒｌｄ"),
+            }]),
             lisp_vline_symbols: None,
             lisp_block_comments: None,
             guile_block_comments: None,
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "smart",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -403,11 +415,9 @@ pub fn lisp_vline_symbols() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -418,14 +428,15 @@ pub fn lisp_vline_symbols() {
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "paren",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -441,11 +452,9 @@ pub fn lisp_sharp_syntax_backtrack() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -456,14 +465,15 @@ pub fn lisp_sharp_syntax_backtrack() {
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "paren",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -479,11 +489,9 @@ pub fn lisp_block_comments() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -494,14 +502,15 @@ pub fn lisp_block_comments() {
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "paren",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -517,11 +526,9 @@ pub fn guile_block_comments() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -532,14 +539,15 @@ pub fn guile_block_comments() {
             scheme_sexp_comments: None,
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "indent",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -555,11 +563,9 @@ pub fn scheme_sexp_comments() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -570,14 +576,15 @@ pub fn scheme_sexp_comments() {
             scheme_sexp_comments: Some(true),
             janet_long_strings: None,
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "indent",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }
@@ -593,11 +600,9 @@ pub fn janet_long_strings() {
             cursor_x: None,
             cursor_line: None,
             tab_stops: None,
-            paren_trails: None
+            paren_trails: None,
         },
-        source: Source {
-            line_no: 0
-        },
+        source: Source { line_no: 0 },
         options: Options {
             cursor_x: None,
             cursor_line: None,
@@ -608,14 +613,15 @@ pub fn janet_long_strings() {
             scheme_sexp_comments: None,
             janet_long_strings: Some(true),
             prev_cursor_x: None,
-            prev_cursor_line: None
-        }
+            prev_cursor_line: None,
+        },
     };
     let input = json!({
         "mode": "paren",
         "text": &case.text,
         "options": &case.options
-    }).to_string();
+    })
+    .to_string();
     let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
     case.check2(answer);
 }

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -9,9 +9,9 @@ extern crate serde_derive;
 #[cfg(not(target_arch = "wasm32"))]
 use std::ffi::{CStr, CString};
 
-const INDENT_MODE_CASES: &'static str = include_str!("cases/indent-mode.json");
-const PAREN_MODE_CASES: &'static str = include_str!("cases/paren-mode.json");
-const SMART_MODE_CASES: &'static str = include_str!("cases/smart-mode.json");
+const INDENT_MODE_CASES: &str = include_str!("cases/indent-mode.json");
+const PAREN_MODE_CASES: &str = include_str!("cases/paren-mode.json");
+const SMART_MODE_CASES: &str = include_str!("cases/smart-mode.json");
 
 type LineNumber = usize;
 type Column = usize;


### PR DESCRIPTION
First off, let me thank you for this wonderful project. It makes editing sexp-based languages a _lot_ easier!

When updating my installation, I noticed a warning from `cargo` that it didn't have an `edition` specified and was falling back to 2015 by default. I took the liberty of forking the project and updating the `Cargo.toml` to include `edition = "2021"`. After that:

- I fixed all the compiler errors and warnings;
- I ran `cargo fmt` to put it all into a single format; and
- Appeased the all-knowing `clippy` by fixing _nearly_ everything it complained about, with two exceptions:
    - I marked one `if-then-else` warning as ok because there was a lot of code commentary on the conditional branches that looked important to keep; and
    - I left one complaint in `c_wrapper` about not documenting the `# Safety` of an unsafe function, as I didn't feel I had the expertise to do so.

Again, this project works like a charm for my needs! Please feel free to completely ignore this PR, pull in only certain changes, or whatever you decide. Cheers!