### PR TITLE
Expose parinfer and types modules as public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ extern crate unicode_segmentation;
 extern crate unicode_width;
 
 mod changes;
-mod parinfer;
-mod types;
+pub mod parinfer;
+pub mod types;
 
 #[macro_use]
 #[cfg(feature = "emacs")]


### PR DESCRIPTION
I was trying to use parinfer as a library and expose the functionality as mcp server [parinfer-mcp-server](https://github.com/VaclavSynacek/parinfer-mcp-server) . And I could not do it without these two bits marked as pub. I am not entirely sure this should be merged in, but it would definitely allow for my use case without relying on my fork of parinfer. Sorry, I'm new to rust and cargo and mostly vibe coding this, but at least my AI also thinks so.