### PR TITLE
Fix Nix derivation warning for useFetchCargoVendor

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -9,8 +9,6 @@ rustPlatform.buildRustPackage rec {
     lockFile = ./Cargo.lock;
   };
 
-  useFetchCargoVendor = true;
-
   nativeBuildInputs = [
     llvmPackages.libclang
     llvmPackages.clang


### PR DESCRIPTION
Remove useFetchCargoVendor attribute. This is enabled by default as of Nixpkgs 25.05 and triggers a warning.