### PR TITLE
Add option to allow unbalanced quotes in line comment (lisp)

### DIFF
--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -71,6 +71,10 @@ const HY_BRACKET_STRINGS_OPTION : YesNoDefaultOption = YesNoDefaultOption {
     name: "hy-bracket-strings",
     description: "recognize #[hy-style[ bracket strings ]hy-style]```",
 };
+const LINE_COMMENT_QUOTES_OPTION: YesNoDefaultOption = YesNoDefaultOption {
+    name: "line-comment-quotes",
+    description: "check for balanced quotes inside line comments.",
+};
 
 fn options() -> getopts::Options {
     let mut options = getopts::Options::new();
@@ -92,6 +96,7 @@ fn options() -> getopts::Options {
         "'clojure', 'guile', 'hy', 'janet', 'lisp', 'racket', 'scheme' (default: 'clojure')",
         "LANG",
     );
+    LINE_COMMENT_QUOTES_OPTION.add(&mut options);
     LISP_BLOCK_COMMENTS_OPTION.add(&mut options);
     LISP_VLINE_SYMBOLS_OPTION.add(&mut options);
     options.optopt(
@@ -138,6 +143,7 @@ struct LanguageFeatures {
     scheme_sexp_comments: bool,
     janet_long_strings: bool,
     hy_bracket_strings: bool,
+    line_comment_quotes: bool,
 }
 
 impl LanguageFeatures {
@@ -150,6 +156,7 @@ impl LanguageFeatures {
             scheme_sexp_comments: false,
             janet_long_strings: false,
             hy_bracket_strings: false,
+            line_comment_quotes: true,
         };
         match language {
             Language::Clojure => Self {
@@ -174,6 +181,7 @@ impl LanguageFeatures {
             Language::Lisp => Self {
                 lisp_vline_symbols: true,
                 lisp_block_comments: true,
+                line_comment_quotes: false,
                 ..common
             },
             Language::Picolisp => Self {
@@ -291,6 +299,10 @@ impl Options {
         self.invertible_flag("hy-bracket-strings")
     }
 
+    fn line_comment_quotes(&self) -> Option<bool> {
+        self.invertible_flag("line-comment-quotes")
+    }
+
     pub fn request(&self, input: &mut dyn Read) -> io::Result<Request> {
         match self.input_type() {
             InputType::Text => {
@@ -302,6 +314,7 @@ impl Options {
                     scheme_sexp_comments,
                     janet_long_strings,
                     hy_bracket_strings,
+                    line_comment_quotes,
                 } = LanguageFeatures::for_language(parse_language(self.matches.opt_str("language")));
                 let mut text = String::new();
                 input.read_to_string(&mut text)?;
@@ -330,6 +343,7 @@ impl Options {
                             .unwrap_or(scheme_sexp_comments),
                         janet_long_strings: self.janet_long_strings().unwrap_or(janet_long_strings),
                         hy_bracket_strings: self.hy_bracket_strings().unwrap_or(hy_bracket_strings),
+                        line_comment_quotes: self.line_comment_quotes().unwrap_or(line_comment_quotes),
                     },
                 })
             }
@@ -342,6 +356,7 @@ impl Options {
                     scheme_sexp_comments,
                     janet_long_strings,
                     hy_bracket_strings,
+                    line_comment_quotes,
                 } = LanguageFeatures::for_language(parse_language(env::var("kak_opt_filetype").ok()));
                 Ok(Request {
                     mode: String::from(self.mode()),
@@ -370,6 +385,7 @@ impl Options {
                         scheme_sexp_comments,
                         janet_long_strings,
                         hy_bracket_strings,
+                        line_comment_quotes,
                     },
                 })
             }
@@ -419,6 +435,12 @@ mod tests {
         assert!(!scheme.options.hy_bracket_strings);
         assert!(!janet.options.hy_bracket_strings);
         assert!(hy.options.hy_bracket_strings);
+
+        assert!(clojure.options.line_comment_quotes);
+        assert!(scheme.options.line_comment_quotes);
+        assert!(janet.options.line_comment_quotes);
+        assert!(hy.options.line_comment_quotes);
+        assert!(!for_args(&["--language=lisp"]).options.line_comment_quotes);
     }
 
     #[test]
@@ -454,6 +476,34 @@ mod tests {
             !for_args(&["--language=lisp", "--no-lisp-block-comments"])
                 .options
                 .lisp_block_comments
+        );
+    }
+
+    #[test]
+    fn line_comment_quotes() {
+        // Default (clojure): enabled
+        assert!(for_args(&[]).options.line_comment_quotes);
+        // Lisp language: disabled
+        assert!(
+            !for_args(&["--language=lisp"]).options.line_comment_quotes
+        );
+        // Explicit flag enables it
+        assert!(
+            for_args(&["--line-comment-quotes"])
+                .options
+                .line_comment_quotes
+        );
+        // Explicit override on lisp
+        assert!(
+            for_args(&["--language=lisp", "--line-comment-quotes"])
+                .options
+                .line_comment_quotes
+        );
+        // Explicit disable on clojure
+        assert!(
+            !for_args(&["--no-line-comment-quotes"])
+                .options
+                .line_comment_quotes
         );
     }
 }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -246,6 +246,7 @@ struct State<'a> {
     scheme_sexp_comments_enabled: bool,
     janet_long_strings_enabled: bool,
     hy_bracket_strings_enabled: bool,
+    line_comment_quotes_enabled: bool,
 
     quote_danger: bool,
     tracking_indent: bool,
@@ -340,6 +341,7 @@ fn get_initial_result<'a>(text: &'a str, options: &Options, mode: Mode, smart: b
         scheme_sexp_comments_enabled: options.scheme_sexp_comments,
         janet_long_strings_enabled: options.janet_long_strings,
         hy_bracket_strings_enabled: options.hy_bracket_strings,
+        line_comment_quotes_enabled: options.line_comment_quotes,
 
         quote_danger: false,
         tracking_indent: false,
@@ -809,6 +811,11 @@ fn in_code_on_unmatched_close_paren(result: &mut State<'_>) -> Result<()> {
 fn on_newline(result: &mut State<'_>) {
     if result.is_in_comment() {
         result.context = In::Code;
+        if !result.line_comment_quotes_enabled {
+            // Line comments end at newline, so any quotes inside them are
+            // just prose and cannot affect parsing of subsequent lines.
+            result.quote_danger = false;
+        }
     }
     result.ch = "";
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,8 @@ pub struct Options {
     pub janet_long_strings: bool,
     #[serde(default = "Options::default_false")]
     pub hy_bracket_strings: bool,
+    #[serde(default = "Options::default_true")]
+    pub line_comment_quotes: bool,
 }
 
 impl Options {
@@ -49,6 +51,10 @@ impl Options {
 
     fn default_false() -> bool {
         false
+    }
+
+    fn default_true() -> bool {
+        true
     }
 
     fn default_comment() -> char {


### PR DESCRIPTION
Fixes https://github.com/eraserhd/parinfer-rust/issues/156

Add `--line-comment-quotes` / `--no-line-comment-quotes` option

## Summary

Adds a new `--line-comment-quotes` / `--no-line-comment-quotes` CLI option to control whether parinfer checks for balanced quotes inside line comments. When disabled, `quote_danger` state is reset at newlines when leaving a `;` line comment, since line comments are self-contained and cannot carry string state across lines.

## Motivation

Valid Common Lisp source files (e.g., ACL2's 28,000-line `axioms.lisp`) contain many comment blocks where quoted phrases wrap across multiple `;` comment lines. These trigger false `quote-danger` errors, making parinfer unusable on these files.

In CL, `;` comments end at the newline — a `"` inside one is just prose text. The existing `quote_danger` tracking was designed for languages where comment-embedded quotes might interact with the parser, but this doesn't apply to line comments in any language.

## Changes

**`src/types.rs`**
- Added `line_comment_quotes: bool` field to `Options` (serde default: `true` for backward compatibility)

**`src/parinfer.rs`**
- Added `line_comment_quotes_enabled: bool` to `State`
- In `on_newline()`: when leaving a line comment and `line_comment_quotes_enabled` is `false`, reset `quote_danger` to `false`

**`src/cli_options.rs`**
- Added `--line-comment-quotes` / `--no-line-comment-quotes` as a `YesNoDefaultOption`
- Language defaults: `true` for all languages except `lisp` (which defaults to `false`)
- Wired through `LanguageFeatures`, `Options`, and both text and kakoune input paths
- Added unit tests for the new option

## Language defaults

| Language  | `line_comment_quotes` |
|-----------|----------------------|
| clojure   | `true` (unchanged)   |
| guile     | `true`               |
| hy        | `true`               |
| janet     | `true`               |
| **lisp**  | **`false`**          |
| picolisp  | `true`               |
| racket    | `true`               |
| scheme    | `true`               |

The option can always be overridden explicitly:
- `--line-comment-quotes` forces checking on (even for `-l lisp`)
- `--no-line-comment-quotes` forces checking off (even for `-l clojure`)

## Testing

- All 34 existing tests pass (no regressions)
- New unit tests cover language defaults and explicit flag overrides
- Verified on ACL2 `axioms.lisp` (28,000+ lines) — processes successfully with `-l lisp`
- Backward compatible: no behavior change for clojure or other languages
