### PR TITLE
Avoid undo explosion when opening a file with bad indentation

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -242,9 +242,18 @@ function! s:process_buffer() abort
         call s:log_diff(l:orig_text, l:response['text'])
         let l:lines = split(l:response["text"], "\n", 1)
         let l:changed = filter(range(len(l:lines)), 'l:lines[v:val] !=# l:orig_lines[v:val]')
-        silent! undojoin
         try
+          undojoin
           call setline(l:changed[0]+1, l:lines[l:changed[0]:l:changed[-1]])
+        catch /E790:/ " undojoin is not allowed after undo
+          " Calling setline() after undojoin failed with E790 starts a new
+          " undo branch and re-does the undo, causing a loop (issue #112).
+          " Don't re-apply the correction and update the state tracking so we
+          " are in sync with the buffer contents.
+          let b:parinfer_previous_text = l:orig_text
+          let b:parinfer_last_changedtick = b:changedtick
+          let w:parinfer_previous_cursor = s:get_cursor_position()
+          return
         catch /E5\(23\|78\|65\):/ " not allowed here / not allowed to change text here / not allowed to chnage text or change window
           " If an event doesn't allow us to modify the buffer, that's OK.
           " Usually another event will happen before a redraw.

--- a/tests/vim/tests-cases.md
+++ b/tests/vim/tests-cases.md
@@ -280,6 +280,25 @@ After `4GO<Enter>(defn h<Enter>  [z]<Enter>z)<Esc>u`:
   y)
 ```
 
+# Undo explosion (#112)
+
+## Undo does not explode the undo tree (#112)
+
+Opening a file with bad indentation causes parinfer to modify it on load.
+Pressing `u` must revert to the original content and not trigger parinfer
+again.
+
+```
+{
+    }
+```
+
+After `uuuuu`:
+```
+{
+    }
+```
+
 # Unicode (#26)
 ## hukka's example (#26)
 


### PR DESCRIPTION
This was caused by the call to setline() after suppressing an undojoin error. Since undojoin failed, setline() was starting a new undo branch.

undojoin fails when the file is first opened because there is no undo block to join with, so we need to catch the error and update the internal state.

Fixes: #112