### PR TITLE
Add check mode: validate structure without modifying text

### DIFF
--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -97,7 +97,7 @@ fn options() -> getopts::Options {
     options.optopt(
         "m",
         "mode",
-        "parinfer mode (indent, paren, or smart) (default: smart)",
+        "parinfer mode (indent, paren, smart, or check) (default: smart)",
         "MODE",
     );
     options.optopt(
@@ -216,6 +216,7 @@ impl Options {
             Some(ref s) if s == "i" || s == "indent" => "indent",
             Some(ref s) if s == "p" || s == "paren" => "paren",
             Some(ref s) if s == "s" || s == "smart" => "smart",
+            Some(ref s) if s == "c" || s == "check" => "check",
             _ => panic!("invalid mode specified for `-m`"),
         }
     }

--- a/src/parinfer.rs
+++ b/src/parinfer.rs
@@ -1840,6 +1840,33 @@ pub fn smart_mode<'a>(text: &'a str, options: &Options) -> Answer<'a> {
     public_result(process_text(text, options, Mode::Indent, smart))
 }
 
+pub fn check_mode<'a>(text: &'a str, options: &Options) -> Answer<'a> {
+    let result = process_text(text, options, Mode::Paren, false);
+    if result.success {
+        Answer {
+            text: Cow::from(text),
+            cursor_x: result.cursor_x,
+            cursor_line: result.cursor_line,
+            success: true,
+            tab_stops: result.tab_stops,
+            paren_trails: result.paren_trails,
+            parens: result.parens,
+            error: None,
+        }
+    } else {
+        Answer {
+            text: Cow::from(text),
+            cursor_x: result.orig_cursor_x,
+            cursor_line: result.orig_cursor_line,
+            success: false,
+            tab_stops: result.tab_stops,
+            paren_trails: result.paren_trails,
+            parens: result.parens,
+            error: result.error,
+        }
+    }
+}
+
 pub fn process(request: &Request) -> Answer {
     let mut options = request.options.clone();
 
@@ -1853,6 +1880,8 @@ pub fn process(request: &Request) -> Answer {
         indent_mode(&request.text, &options)
     } else if request.mode == "smart" {
         smart_mode(&request.text, &options)
+    } else if request.mode == "check" {
+        check_mode(&request.text, &options)
     } else {
         Answer::from(Error {
             message: String::from("Bad value specified for `mode`"),
@@ -1876,6 +1905,8 @@ pub fn rc_process(request: &SharedRequest) -> Answer<'_> {
         indent_mode(&request.text, &options)
     } else if request.mode == "smart" {
         smart_mode(&request.text, &options)
+    } else if request.mode == "check" {
+        check_mode(&request.text, &options)
     } else {
         Answer::from(Error {
             message: String::from("Bad value specified for `mode`"),

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -12,6 +12,7 @@ use std::ffi::{CStr, CString};
 const INDENT_MODE_CASES: &str = include_str!("cases/indent-mode.json");
 const PAREN_MODE_CASES: &str = include_str!("cases/paren-mode.json");
 const SMART_MODE_CASES: &str = include_str!("cases/smart-mode.json");
+const CHECK_MODE_CASES: &str = include_str!("cases/check-mode.json");
 
 type LineNumber = usize;
 type Column = usize;
@@ -276,6 +277,21 @@ pub fn smart_mode() {
     for case in cases {
         let input = json!({
             "mode": "smart",
+            "text": &case.text,
+            "options": &case.options
+        })
+        .to_string();
+        let answer: serde_json::Value = serde_json::from_str(&run(&input)).unwrap();
+        case.check2(answer);
+    }
+}
+
+#[test]
+pub fn check_mode() {
+    let cases: Vec<Case> = serde_json::from_str(CHECK_MODE_CASES).unwrap();
+    for case in cases {
+        let input = json!({
+            "mode": "check",
             "text": &case.text,
             "options": &case.options
         })

--- a/tests/cases/check-mode.json
+++ b/tests/cases/check-mode.json
@@ -1,0 +1,67 @@
+[
+  {
+    "text": "(defn foo [x]\n  (+ x 1))",
+    "options": {},
+    "result": {
+      "text": "(defn foo [x]\n  (+ x 1))",
+      "success": true
+    },
+    "source": {
+      "lineNo": 1,
+      "in": [
+        "(defn foo [x]\n  (+ x 1))"
+      ],
+      "out": "(defn foo [x]\n  (+ x 1))"
+    }
+  },
+  {
+    "text": "(let [a 1\n      ])",
+    "options": {},
+    "result": {
+      "text": "(let [a 1\n      ])",
+      "success": true
+    },
+    "source": {
+      "lineNo": 10,
+      "in": [
+        "(let [a 1\n      ])"
+      ],
+      "out": "(let [a 1\n      ])"
+    }
+  },
+  {
+    "text": "(foo",
+    "options": {},
+    "result": {
+      "error": {
+        "name": "unclosed-paren",
+        "lineNo": 0,
+        "x": 0
+      },
+      "text": "(foo",
+      "success": false
+    },
+    "source": {
+      "lineNo": 19,
+      "in": [
+        "(foo"
+      ],
+      "out": "(foo\n^ error: unclosed-paren"
+    }
+  },
+  {
+    "text": "(cond->\n {:auth-token auth-token\n  :request request\n  :action-id action}\n  target-service-id (assoc :target-service-id target-service-id)\n  resource (assoc :resource resource))",
+    "options": {},
+    "result": {
+      "text": "(cond->\n {:auth-token auth-token\n  :request request\n  :action-id action}\n  target-service-id (assoc :target-service-id target-service-id)\n  resource (assoc :resource resource))",
+      "success": true
+    },
+    "source": {
+      "lineNo": 9999,
+      "in": [
+        "(cond->\n {:auth-token auth-token\n  :request request\n  :action-id action}\n  target-service-id (assoc :target-service-id target-service-id)\n  resource (assoc :resource resource))"
+      ],
+      "out": "(cond->\n {:auth-token auth-token\n  :request request\n  :action-id action}\n  target-service-id (assoc :target-service-id target-service-id)\n  resource (assoc :resource resource))"
+    }
+  }
+]


### PR DESCRIPTION
New --mode check (or -m c) runs the paren-mode parser for validation only, returning the original text unchanged. Returns success:true for structurally balanced files, success:false with error details for unbalanced files.

This enables a two-phase gate pattern for editor plugins:
  1. check mode → balanced? → done, no rewrite
  2. check mode → unbalanced? → smart/indent mode to repair

Prevents a cond-> corruption bug where smart mode's indent-mode heuristics move closing braces past sibling clauses in balanced files. The fix is at the [plugin](https://github.com/gtrak/parinfer-rust-opencode/commit/813a54d2f56aebfc6bc795ba0e3ef33787be2d16) level: balanced files never reach smart mode.

Minimal failing example:
```
$ printf '(cond->\n {:a 1}\n  x y)' | ./target/release/parinfer-rust --mode smart --input-format text --output-format text

output:
(cond->
 {:a 1
  x y})
```

Disclaimer: used LLMs