### PR TITLE
docs: add vim.pack installation instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,22 @@ $ cargo build --release --features emacs
 
 === Vim and Neovim
 
+==== `+vim.pack+` (Neovim >= 0.12)
+
+[source,lua]
+----
+vim.api.nvim_create_autocmd('PackChanged', {
+  callback = function(ev)
+    local name, kind = ev.data.spec.name, ev.data.kind
+    if name == 'parinfer-rust' and (kind == 'install' or kind == 'update') then
+      vim.system({ 'cargo', 'build', '--release' }, { cwd = ev.data.path })
+    end
+  end,
+})
+
+vim.pack.add { 'https://github.com/eraserhd/parinfer-rust' }
+----
+
 ==== `+pathogen+`
 
 If you are using Tim Pope’s `+pathogen+`:


### PR DESCRIPTION
- Add `vim.pack` installation method to the Vim and Neovim section of the README